### PR TITLE
docs(logging): fix spelling of console

### DIFF
--- a/advanced/javascript/logging.md
+++ b/advanced/javascript/logging.md
@@ -29,7 +29,7 @@ If you want to log something inline you can use `evalScript` to output it to the
 
 const myVar = 'foo';
 console.log(myVar); // outputs 'foo'
-consolel.log(`myVar is ${myVar}`) // outputs 'myVar is foo'
+console.log(`myVar is ${myVar}`) // outputs 'myVar is foo'
 ```
 
 {% content-ref url="../../api-reference/commands/runscript.md" %}


### PR DESCRIPTION
Fix the spelling of console so the snippet is copy-pastable