### PR TITLE
Update conditions.md

### DIFF
--- a/advanced/conditions.md
+++ b/advanced/conditions.md
@@ -39,6 +39,7 @@ By design, Maestro discourages the usage of conditional statements unless absolu
       platform: iOS
     file: {reference to another yaml file}
 ```
+Note that multiple conditions are applied as AND conditions.
 
 ### Conditions
 


### PR DESCRIPTION
A simple note that multiple conditions are applied as AND conditions, not OR. This [has come up in the Maestro Slack](https://mobile-dev-inc.slack.com/archives/C041FU72T54/p1683887683739869), and seemed like a reasonable thing to clarify right in the docs.