### PR TITLE
[docs `inputtext.md`] Unicode characters supported in iOS, but not supported in android yet

### DIFF
--- a/api-reference/commands/inputtext.md
+++ b/api-reference/commands/inputtext.md
@@ -7,7 +7,7 @@ Inputs text (regardless of whether any text field is currently focused or not)
 ```
 
 {% hint style="warning" %}
-Unfortunately unicode characters are not supported yet. Follow the [GitHub issue](https://github.com/mobile-dev-inc/maestro/issues/146) for status updates.
+Unfortunately unicode characters are not supported yet in Android platform. Follow the [GitHub issue](https://github.com/mobile-dev-inc/maestro/issues/146) for status updates.
 {% endhint %}
 
 ### Input random text


### PR DESCRIPTION
Hello, I'm @coffmark. Thanks for your maintaining.

## Describe your changes

- Describe unicode character support in iOS.

I have confirmed unicode characters supported in iOS, and @dmitry-zaitsev  also says it works. https://github.com/mobile-dev-inc/maestro/issues/146#issuecomment-1408627114

## Issue ticket link

- None
- [Here](https://github.com/mobile-dev-inc/maestro/issues/146) is the link to this issue, but I can't close it yet.

Looking forward to good reply ! 
Thank you!