### PR TITLE
docs: fix branding, typos, and other minor changes

### DIFF
--- a/getting-started/installing-maestro/windows.md
+++ b/getting-started/installing-maestro/windows.md
@@ -1,5 +1,5 @@
 ---
-description: A step by step guide to install Maestro in Windows
+description: A step by step guide to installing Maestro on Windows
 ---
 
 # Windows
@@ -8,13 +8,13 @@ Maestro works great on Windows computers, but there are a few unique setup steps
 
 ### Pre-Requisites
 
-1. Powershell is installed in Windows system.
-2. Install android studio in windows machine.
-3. Add ANDROID\_HOME to your windows environment variable.
-   1. To check if your ANDROID\_HOME setup is correctly done, open a powershell terminal and run this command `adb --version.`
-   2. Note down the adb version.
+1. PowerShell is installed in your Windows system.
+2. Install Android Studio on your Windows machine.
+3. Add ANDROID\_HOME to your Windows environment variable.
+   1. To check if your ANDROID\_HOME setup is correctly done, open a PowerShell terminal and run this command `adb --version.`
+   2. Note down the ADB version.
 4. Install Java JDK 11 and set JAVA\_HOME
-   1. Run `java  --version` to check if the java is installed correctly.
+   1. Run `java  --version` to check if the Java is installed correctly.
 
 ## Steps <a href="#8b4a" id="8b4a"></a>
 
@@ -24,9 +24,9 @@ Maestro works great on Windows computers, but there are a few unique setup steps
 
 ## 1. Install WSL 2 <a href="#0215" id="0215"></a>
 
-With recent Windows 11, Microsoft have made it pretty easy to install Windows Subsystem For Linux aka WSL
+With recent Windows 11, Microsoft has made it pretty easy to install Windows Subsystem for Linux, aka WSL.
 
-In order to install WSL, open Powershell As Administrator and run following command:
+In order to install WSL, open PowerShell as administrator and run the following command:
 
 ```bash
 wsl --install
@@ -36,9 +36,9 @@ After running the above command, follow through instructions and restart the com
 
 Install [Windows Terminal](https://github.com/microsoft/terminal) application for refreshing terminal experience.
 
-Set your linux username and password (Something that you will not forget).
+Set your Linux username and password (Something that you will not forget).
 
-Run following 2 commands to update your Ubuntu system. Enter password when prompted.
+Run the following two commands to update your Ubuntu system. Enter password when prompted.
 
 ```bash
 sudo apt update
@@ -47,7 +47,7 @@ sudo apt upgrade
 
 ## 2. Install Java <a href="#5521" id="5521"></a>
 
-After restarting the system, open Terminal application and click on the dropdown to select Ubuntu. Type in following command:
+After restarting the system, open the Terminal application and click on the dropdown to select Ubuntu. Type in the following command:
 
 ```bash
 sudo apt install openjdk-11-jdk
@@ -61,24 +61,24 @@ Installing Maestro is now just a matter of running following one command.
      curl -Ls "https://get.maestro.mobile.dev" | bash
 ```
 
-**TADA!**
+**Tada! 🎉**
 
-**You have successfully installed Maestro in your Windows machine** 🙌
+**You have successfully installed Maestro on your Windows machine** 🙌
 
-Check your maestro version using following command
+Check your Maestro version using the following command:
 
 ```bash
 maestro --version
 ```
 
-## What Next? <a href="#7639" id="7639"></a>
+## What's Next? <a href="#7639" id="7639"></a>
 
-### Let's set you up to use android in your freshly installed WSL2
+### Let's set you up to use Android in your freshly installed WSL2
 
 
 
-* Download android command line tools zip file from [android official site.](https://developer.android.com/studio)
-*   Use the following instructions to setup android command lines correctly in your WSL2 .
+* Download the Android command line tools zip file from [Android official site.](https://developer.android.com/studio)
+*   Use the following instructions to set up Android command lines correctly in your WSL2.
 
     * Open WSL2 terminal.
     * Create a new directory in your home directory.
@@ -88,7 +88,7 @@ maestro --version
     ~ $ cd Android
     ```
 
-    * Unzip the android command line tools zip file in the `android` directory using this command: `unzip ~<command_line_zip_filename>.zip`
+    * Unzip the Android command line tools zip file in the `android` directory using this command: `unzip ~<command_line_zip_filename>.zip`
     * In the `android` directory:
 
     ```
@@ -107,44 +107,42 @@ maestro --version
 
     * Save your `~/.bashrc` file and exit.
     * Run `source ~/.bashrc` to reload the bashrc file.
-    * Now we will install basic android utilities using following commands:
+    * Now, we will install basic Android utilities using the following commands:
       * Run `sdkmanager --list` to check if everything is working fine.
       * Run `sdkmanager --install "platform-tools"` to install platform tools.
-    * Finally add following into your `~/.bashrc` file
+    * Finally, add the following into your `~/.bashrc` file
       * `export PATH=$PATH:$ANDROID_HOME/platform-tools/:$PATH`
       * Save your `~/.bashrc` file and exit.
       * Run `source ~/.bashrc` to reload the bashrc file.
-    * To check that everything went good, do following:
+    * To check that everything went well, do the following:
       * Close and relaunch terminal
       * Run `adb --version` and see that adb version is shown
-      * Since everything is installed fresh, your WSL 2 adb version should perfectly match with windows adb version that we noted down as part of pre-requisites.
+      * Since everything is installed fresh, your WSL 2 adb version should perfectly match with Windows ADB version that we noted down as part of the pre-requisites.
 
 
 
-**Please follow below steps to setup the ADB and make sure you are able to use android emulators with your WSL2 correctly**
+**Please follow the below steps to setup the ADB and make sure you are able to use Android emulators with your WSL2 correctly**
 
-* Fire up your android emulator on windows.
-* Once android emulator is up and running, open a POWERSHELL PROMPT.
-*   Run this command in Powershell
+* Fire up your Android emulator on Windows.
+* Once the Android emulator is up and running, open a PowerShell prompt.
+*   Run this command in PowerShell
 
     ```
     adb -a -P 5037 nodaemon server
     ```
 
-    * This will start the adb server in windows host.
-    * Note down the IPV4 address of your windows host PC/machine.
+    * This will start the adb server in the Windows host.
+    * Note down the IPV4 address of your Windows host PC/machine.
 
     **TROUBLESHOOTING:**
 
-    * Sometimes you may get `smartsockets..` error when you run `adb -a -P 5037 nodaemon server` command in powershell. In that case you can do following steps:
+    * Sometimes you may get `smartsockets..` error when you run `adb -a -P 5037 nodaemon server` command in PowerShell. In that case, you can do the following steps:
       * Open task manager and kill all `adb` related processes.
-      * If Android studio is open, close it and KEEP ONLY emulator running.
-      * If you see a message saying `emulator offline`, IGNORE IT.
-      * Sometimes, firewall stops your connection with host machine. For that add a firewall rule to allow the connection or check with your organization system admin if using company machine.
+      * If Android Studio is open, close it and **keep only** emulator running.
+      * If you see a message saying `emulator offline`, **ignore it**.
+      * Sometimes, the firewall stops your connection with the host machine. For that, add a firewall rule to allow the connection or check with your organization system admin if using a company machine.
 
-    \
-
-* **Note: Don't close the powershell terminal.!!**
+* **Note: Don't close the PowerShell terminal!**
 * **Now open your WSL2 terminal and run these commands.**
   * `adb kill-server`
   * `export ADB_SERVER_SOCKET=tcp:<WINDOWS_IPV4_ADDR>:5037`
@@ -155,11 +153,11 @@ maestro --version
 
 ### Ready to start Using Maestro?
 
-Yes at this point you are free to start your automation.
+Yes, at this point, you are free to start your automation.
 
 * [Write your first flow](https://maestro.mobile.dev/getting-started/writing-your-first-flow)
 * How to run **Maestro commands**?
-  * You can run maestro commands in WSL2 terminal with `--host` flag. eg.
+  * You can run Maestro commands in WSL2 terminal with `--host` flag. eg.
     * _**maestro --host \<WINDOWS\_IPV4\_ADDR> test flow.yaml**_
     * _**maestro --host \<WINDOWS\_IPV4\_ADDR> studio**_
 * Check out the [full documentation](https://maestro.mobile.dev/)
@@ -169,8 +167,8 @@ Yes at this point you are free to start your automation.
 
 
 ```
-If your android emulator is not up and running in windows host, the maestro test
-command fails to find installed emulator.
-At this point it is recommended that you fire up emulator before running the flow 
-using maestro.
+If your Android emulator is not up and running in the Windows host, the Maestro test
+command fails to find the installed emulator.
+At this point, it is recommended that you fire up your emulator before running the flow 
+using Maestro.
 ```


### PR DESCRIPTION
This PR updates the docs for the "Installing on Windows" page by namely:

- Updating branding capitalizations such as "PowerShell" and "Android Studio" from all-lowercase
- Adding small transition words to fix grammar
- Add punctuation
- Fix errant Markdown mistakes