### PR TITLE
docs: fix childof relative selector example

### DIFF
--- a/api-reference/selectors.md
+++ b/api-reference/selectors.md
@@ -39,8 +39,8 @@ Apart from the selectors mentioned above, Maestro is also able to select views u
     leftOf: "View to the right has this text"
     rightOf: "View to the left has this text"
     containsChild: "Text in a child view"      # This will match a view that has a *direct* child view with the given text
-    childOf:                                   # This will help to select from children of view with id 'buy-now'
-        - id: "buy-now"
+    childOf:                                   # This will match a view that is a child of a view with id 'buy-now'
+        id: "buy-now"
     containsDescendants:                       # This will match a view that has all the descendant views given below
         - id: "title_id"
           text: "A descendant view has id 'title_id' and this text"


### PR DESCRIPTION
The docs show `childOf` as accepting a sequence, but really it should accept a map.  Also, made the comment describing `childOf` more clear.

See example in main repo:

https://github.com/mobile-dev-inc/maestro/blob/0b5a0e2670bcacda262c3588577683980c6d8887/maestro-test/src/test/resources/114_child_of_selector.yaml#L3-L10