### PR TITLE
Fix broken link in the javascript docs

### DIFF
--- a/advanced/javascript/access-element-text.md
+++ b/advanced/javascript/access-element-text.md
@@ -1,6 +1,6 @@
 # Access element text
 
-In order to access text of UI elements, use `copyTextFrom` [command.](https://maestro.mobile.dev/reference/keyboard/copy-and-paste-text) The text can then be accessed via `maestro.copiedText` variable:
+In order to access text of UI elements, use `copyTextFrom` [command](../../api-reference/commands/copytextfrom.md). The text can then be accessed via `maestro.copiedText` variable:
 
 ```
 - copyTextFrom: My Field


### PR DESCRIPTION
Spotted a broken link in the Access element text page: https://maestro.mobile.dev/advanced/javascript/access-element-text

Fixed it, and made it a relative markdown link rather than a hyperlink. Somehow, that felt cleaner, but no objections to someone changing it to a plain `https://maestro.mobile.dev/api-reference/commands/copytextfrom` link.