### PR TITLE
Added location of reacording in startrecording.md

### DIFF
--- a/api-reference/commands/scrolluntilvisible.md
+++ b/api-reference/commands/scrolluntilvisible.md
@@ -20,6 +20,12 @@ The scroll will move towards the direction specified `DOWN|UP|LEFT|RIGHT`. For e
 
 
 
+### Timeout
+
+The timeout (in miliseconds) defines how long it should scroll and look for the specified element. The test fails if the timeout ends before the specified element is visible. If the element is visible, the test will move on with the next command / step.
+
+
+
 ### Center Element
 
 If enabled, it will attempt to stop when the element is closer to the screen center.&#x20;

--- a/api-reference/commands/startrecording.md
+++ b/api-reference/commands/startrecording.md
@@ -13,7 +13,7 @@ appId: yourAppId
 ...
 ```
 
-Your recording will then be available
+Your recording will then be available in your test directory.
 
 {% content-ref url="stoprecording.md" %}
 [stoprecording.md](stoprecording.md)


### PR DESCRIPTION
Im not quite sure if this is a configurable thing, but i was searching for the recording in the logs & screenshots folder to then later notice that it is in the same project directory as the test itself. So I suggest adding that to the docs to save some small headaches for the first timers :)