### PR TITLE
docs: Create resources.md

### DIFF
--- a/community/resources.md
+++ b/community/resources.md
@@ -1,0 +1,9 @@
+---
+description: A list of articles, blog posts and tutorials
+---
+
+# Resources
+
+* Blog Post: [**Introducing: Maestro — Painless Mobile UI Automation**](https://blog.mobile.dev/introducing-maestro-painless-mobile-ui-automation-bee4992d13c1)
+* GitHub Repository: [**https://github.com/mobile-dev-inc/maestro**](https://github.com/mobile-dev-inc/maestro)
+* Public Slack Channel: [**Join the workspace**](https://docsend.com/view/3r2sf8fvvcjxvbtk), then head to the `#maestro` channel


### PR DESCRIPTION
If a developer is looking for community resources, such as a Slack channel, the logical place for them to look is under the "Community" heading of the docs. However, currently the only place the Slack channel is listed is in the first page, under "What is Maestro?" Many experienced developers won't read this whole page, and it's not really a logical place to look to find something like a Slack channel. 

This PR simply adds the "Resources" section of "What is Maestro?" as its own section under Community, to facilitate people finding the Maestro Slack and similar resources.