### PR TITLE
Remove PATH variable duplication in windows installation

### DIFF
--- a/getting-started/installing-maestro/windows.md
+++ b/getting-started/installing-maestro/windows.md
@@ -101,7 +101,7 @@ maestro --version
 
     ```
     export ANDROID_HOME=$HOME/Android
-    export PATH=$PATH:$ANDROID_HOME/cmdline-tools/latest/bin/:$PATH
+    export PATH=$PATH:$ANDROID_HOME/cmdline-tools/latest/bin
     ```
 
     * Save your `~/.bashrc` file and exit.
@@ -110,7 +110,7 @@ maestro --version
       * Run `sdkmanager --list` to check if everything is working fine.
       * Run `sdkmanager --install "platform-tools"` to install platform tools.
     * Finally, add the following into your `~/.bashrc` file
-      * `export PATH=$PATH:$ANDROID_HOME/platform-tools/:$PATH`
+      * `export PATH=$PATH:$ANDROID_HOME/platform-tools`
       * Save your `~/.bashrc` file and exit.
       * Run `source ~/.bashrc` to reload the bashrc file.
     * To check that everything went well, do the following:


### PR DESCRIPTION
Windows installation documentation says to modify PATH variable as follows:
```bash
#           ↓↓↓↓↓                                         ↓↓↓↓↓
export PATH=$PATH:$ANDROID_HOME/cmdline-tools/latest/bin/:$PATH
```

If you look closely, old PATH variable is being duplicated. What is worse, documentation says to edit path variable one more time, with exact same error:
```bash
export PATH=$PATH:$ANDROID_HOME/platform-tools/:$PATH
```

This leads to quadrupling original PATH variable, and in practice, has no real effect, other than polluted PATH variable.