### PR TITLE
Document existing environment variables

### DIFF
--- a/api-reference/configuration/workspace-configuration.md
+++ b/api-reference/configuration/workspace-configuration.md
@@ -29,3 +29,16 @@ excludeTags:
 
 There are other workspace configuration options available that relate to Maestro Cloud which are not outlined here. Please refer to the [Maestro Cloud documentation](https://cloud.mobile.dev/) for more information.
 
+## Environment variables
+
+| Variable name                  | Description                                                                                                    | Type    | Default                  | Further reading                                              |
+|--------------------------------|----------------------------------------------------------------------------------------------------------------|---------|--------------------------| ------------------------------------------------------------ |
+| MAESTRO_API_URL                | The URL of the Maestro API to use. Probably only useful to Mobile Inc developers.                              | String  | `https://api.mobile.dev` | -                                                            |
+| MAESTRO_CLI_AI_KEY             | Key for external AI service used in AI operations.                                                             | String  | -                        | [Docs](ai-configuration.md).                                 |
+| MAESTRO_CLI_NO_ANALYTICS       | Disables Maestro analytics collection                                                                          | Boolean | `false`                  | -                                                            |
+| MAESTRO_CLOUD_API_KEY          | The API key to use when communicating with Maestro Cloud                                                       | String  | -                        | [Maestro Cloud documentation](https://cloud.mobile.dev/)     |
+| MAESTRO_DISABLE_UPDATE_CHECK   | Disable the check for newer Maestro versions when running the CLI                                              | Boolean | `false`                  | -                                                            |
+| MAESTRO_DRIVER_STARTUP_TIMEOUT | The maximum time to wait for a driver to start.                                                                | Number  | `15000`                  | [Docs](../../advanced/configuring-maestro-driver-timeout.md) |
+| MAESTRO_USE_GRAALJS            | Use GraalJS instead of RhinoJS for JavaScript execution                                                        | Boolean | `false`                  | [Docs](../../advanced/javascript/graaljs-support.md).        |
+
+Any other environment variables prefixed with `MAESTRO_` will be available in your Flows as JavaScript variables. See [Accessing variables from the shell](../../advanced/parameters-and-constants.md#accessing-variables-from-the-shell) for more information.


### PR DESCRIPTION
Collects info from across the docs and the codebase to pull together all currently existing environment variables.

Except `MDEV_CI` because I'm not sure of its purpose.