### PR TITLE
Update docs page about detecting Maestro with Android background thread

### DIFF
--- a/advanced/detect-maestro-in-your-app.md
+++ b/advanced/detect-maestro-in-your-app.md
@@ -16,20 +16,21 @@ fun isMaestro(): Boolean {
 }
 ```
 
-Depending on various variables in your testing setup, the code block above might give you a `NetworkOnMainThreadException `. Get rid of the exception by moving the boolean check to a Coroutine background thread for the `Socket` usage to work without a crash:
+An alternative is to use [arguments](../api-reference/commands/launchapp.md#launch-arguments) and have your app detect a particular parameter to indicate Maestro's usage, e.g. `isE2ETest`.
+
+
+### NetworkOnMainThreadException
+
+On Android, you may encounter a `NetworkOnMainThreadException`. This means you'll need to move the call above to a background thread. As an example:
 
 ```kotlin
-viewModel.viewModelScope.launch(Dispatchers.Default) {
-
-     val isMaestroTestSituation = isMaestro()
-     
-     // If need be, update UI or take other actions on the main UI thread 
-     withContext(Main) {
-         // button.isVisible = isMaestroTestSituation
-     }
+CoroutineScope(Dispatchers.IO).launch {
+    if (isMaestro()) {
+        // Do Maestro things
+        
+    }
 }
 ```
 
-An alternative to all of this is to use [arguments](../api-reference/commands/launchapp.md#launch-arguments) and have your app detect a particular parameter to indicate Maestro's usage, e.g. `isE2ETest`.
 
 

--- a/advanced/detect-maestro-in-your-app.md
+++ b/advanced/detect-maestro-in-your-app.md
@@ -16,4 +16,20 @@ fun isMaestro(): Boolean {
 }
 ```
 
-An alternative is to use [arguments](../api-reference/commands/launchapp.md#launch-arguments) and have your app detect a particular parameter to indicate Maestro's usage, e.g. `isE2ETest`.
+Depending on various variables in your testing setup, the code block above might give you a `NetworkOnMainThreadException `. Get rid of the exception by moving the boolean check to a Coroutine background thread for the `Socket` usage to work without a crash:
+
+```kotlin
+viewModel.viewModelScope.launch(Dispatchers.Default) {
+
+     val isMaestroTestSituation = isMaestro()
+     
+     // If need be, update UI or take other actions on the main UI thread 
+     withContext(Main) {
+         // button.isVisible = isMaestroTestSituation
+     }
+}
+```
+
+An alternative to all of this is to use [arguments](../api-reference/commands/launchapp.md#launch-arguments) and have your app detect a particular parameter to indicate Maestro's usage, e.g. `isE2ETest`.
+
+


### PR DESCRIPTION
This pr updates [the docs page about detecting Maestro](https://maestro.mobile.dev/advanced/detect-maestro-in-your-app) with more info about using Android background thread

Based on my original thread in the mobile.dev Slack workspace 👇🏽 :

<img width="587" alt="Screenshot 2024-09-16 at 6 04 26 PM" src="https://github.com/user-attachments/assets/8fd948cd-4b45-4942-896e-21e695b26c4a">
<img width="577" alt="Screenshot 2024-09-16 at 6 04 34 PM" src="https://github.com/user-attachments/assets/e7e42f6f-04cd-4115-92ae-22bbe7d8f4b8">
