### PR TITLE
Add redirect docs for longPressOn command

### DIFF
--- a/api-reference/commands/longpresson.md
+++ b/api-reference/commands/longpresson.md
@@ -1,0 +1,3 @@
+# longPressOn
+
+Like tapOn, but for longer presses. See the [tapOn](tapon.md#long-press) docs for examples.


### PR DESCRIPTION
Fixes it not being a directly referenced command in the API.