### PR TITLE
Expo doc links

### DIFF
--- a/community/contributions.md
+++ b/community/contributions.md
@@ -8,6 +8,7 @@ description: A list of community projects and contributions around Maestro.
   Maestro Assistant is a Visual Studio Code extension that provides useful Maestro shortcuts and simplifies repetitive workflows, like creating or running flows.
 * [React Native Maestro](https://github.com/kiki-le-singe/react-native-maestro)\
   A sample project that uses Maestro to test a React Native app built with Expo.
+* [E2E testing of React Native apps using EAS and Maestro (Expo documentation)](https://docs.expo.dev/build-reference/e2e-tests/)
 * [Codemagic CI integration](https://docs.codemagic.io/integrations/maestro-integration/)
 * [Fastlane Plugin](https://github.com/inf2381/fastlane-plugin-maestro)
 * [ASDF Plugin](https://github.com/dotanuki-labs/asdf-maestro)

--- a/platform-support/react-native.md
+++ b/platform-support/react-native.md
@@ -178,7 +178,5 @@ In some cases, you may run into issues with nested tappable / accessible element
 ## Resources
 
 * [A great introduction to Maestro with React Native](https://dev.to/b42/test-your-react-native-app-with-maestro-5bfj) by Alexander Hodes
+* [E2E testing of React Native apps using EAS and Maestro (Expo documentation)](https://docs.expo.dev/build-reference/e2e-tests/)
 
-{% content-ref url="broken-reference" %}
-[Broken link](broken-reference)
-{% endcontent-ref %}


### PR DESCRIPTION
Adding links to Expo's official documentation on using Maestro to test Expo apps (including Expo Router navigation).