### PR TITLE
chore: add note on MAESTRO_FILENAME being available by default

### DIFF
--- a/advanced/parameters-and-constants.md
+++ b/advanced/parameters-and-constants.md
@@ -130,3 +130,9 @@ Of course, since all env declarations are also JavaScript expressions, you can a
       USERNAME: ${MAESTRO_ENV_USER}
       PASSWORD: ${MAESTRO_ENV_PASSWORD}
 ```
+
+### Built-in parameters
+
+The following parameters are built-in and available in all flows without needing to be defined:
+
+* `MAESTRO_FILENAME`: The filename of the current flow (e.g. `flow.yaml`)


### PR DESCRIPTION
See [this Slack thread](https://maestro--dev.slack.com/archives/C041FU72T54/p1752087385374759) for context. The **TLDR** (since that message will be lost after 90 days) is that the current availability of `MAESTRO_FILENAME` was not documented, so I'm adding a note in what I _think_ is the best place for this. Please let me know if I should add anything else; I felt I didn't need to add example usages because the rest of this page already does a good job of demonstrating that.