### PR TITLE
fix output.script syntax in HTTP requests examples

### DIFF
--- a/advanced/javascript/make-http-s-requests.md
+++ b/advanced/javascript/make-http-s-requests.md
@@ -12,7 +12,7 @@ Maestro comes with its own JavaScript HTTP API
 // script.js
 const response = http.get('https://example.com')
 
-output.script.result = response.body
+output.script = response.body
 ```
 
 ### JSON
@@ -35,7 +35,7 @@ For example, assume that `https://example.com/jsonEndpoint` returns the followin
 // script.js
 const response = http.get('https://example.com/jsonEndpoint')
 
-output.script.result = json(response.body).myField.mySubField
+output.script = json(response.body).myField.mySubField
 ```
 
 ### POST request


### PR DESCRIPTION
## Description
Fixes incorrect syntax in the HTTP requests documentation that causes a runtime error.

## Problem
The documentation currently shows:
```javascript
output.script.result = json(response.body).myField.mySubField
```

This causes the following error:
```
TypeError: Cannot set property "result" of undefined to "xyz"
```

## Solution
Changed to the correct syntax:
```javascript
output.script = json(response.body).myField.mySubField
```