### PR TITLE
Clarify maestro driver startup timeout configuration

### DIFF
--- a/advanced/configuring-maestro-driver-timeout.md
+++ b/advanced/configuring-maestro-driver-timeout.md
@@ -4,9 +4,9 @@ description: >-
   failures in slow environments.
 ---
 
-# Configure Maestro Driver Timeout for Reliable Tests
+# Configure Maestro Driver Startup Timeout for Reliable Tests
 
-In some environments with limited performance, such as CI/CD, it may be necessary to increase the maestro driver's default timeout. For this, you can set the environment `MAESTRO_DRIVER_STARTUP_TIMEOUT`, setting how many milliseconds you want.
+In some environments with limited performance, such as CI/CD, it may be necessary to increase the maestro driver's default startup timeout. For this, you can set the environment `MAESTRO_DRIVER_STARTUP_TIMEOUT`, setting how many milliseconds you want.
 
 The default value is `15000` (15 seconds)
 


### PR DESCRIPTION
Updated the title and clarified the description regarding the maestro driver startup timeout.

At first, I thought this was related to the default driver's timeout, for also other things beyond starting up, and only reading the original Github issue I was able to understand that this env var is only related to startup:
https://github.com/mobile-dev-inc/Maestro/pull/1017