### PR TITLE
Fix `launchApp` YAML syntax in API reference

### DIFF
--- a/api-reference/commands/launchapp.md
+++ b/api-reference/commands/launchapp.md
@@ -71,7 +71,7 @@ To launch or stop a different app
 To bring a backgrounded app to the foreground without restarting it
 
 ```yaml
-- launchApp
+- launchApp:
     stopApp: false
 ```
 


### PR DESCRIPTION
## Fix `launchApp` YAML syntax in API reference

### Summary

This PR fixes a small but important YAML syntax issue in the `launchApp` command documentation.

The example was missing a trailing colon (`:`) after `launchApp`, which made the snippet invalid YAML and could cause confusion or copy-paste errors for users.

### What changed

* Updated the YAML example to correctly use:

  ```yaml
  - launchApp:
      stopApp: false
  ```
* No functional or behavioural changes. Documentation only.

### Why this matters

* Ensures the example is **valid YAML**
* Prevents runtime errors when users copy examples directly
* Improves clarity and trust in the API reference

### Scope

* Documentation only
* No breaking changes
* No code or behaviour impact

### Before / After

**Before (invalid YAML):**

```yaml
- launchApp
    stopApp: false
```

**After (valid YAML):**

```yaml
- launchApp:
    stopApp: false
```
