### PR TITLE
Fix Homebrew install command to avoid installing wrong package

### DIFF
--- a/getting-started/installing-maestro/README.md
+++ b/getting-started/installing-maestro/README.md
@@ -35,9 +35,10 @@ curl -fsSL "https://get.maestro.mobile.dev" | bash
 If you're on macOS, you can use Homebrew instead of the install script above:
 
 ```bash
-brew tap mobile-dev-inc/tap
-brew install maestro
+brew install mobile-dev-inc/tap/maestro
 ```
+
+> **Note:** Do not use `brew install maestro` as this will install a different application. Always use the fully qualified formula name above.
 
 ## Upgrading the CLI
 


### PR DESCRIPTION
## Summary
- Changed Homebrew install command from `brew tap mobile-dev-inc/tap` + `brew install maestro` to `brew install mobile-dev-inc/tap/maestro`
- Added a note warning users not to use `brew install maestro`

## Problem
The command `brew install maestro` is ambiguous. There's a Homebrew cask named `maestro` that installs a completely different application (Maestro AI from runmaestro.ai). Even after running `brew tap mobile-dev-inc/tap`, running `brew install maestro` still installs the wrong package.

## Solution
Using the fully qualified formula name `brew install mobile-dev-inc/tap/maestro` ensures the correct package is installed. This also has the benefit of automatically tapping the repository, so the separate `brew tap` command is no longer needed.

Fixes mobile-dev-inc/Maestro#2912