### PR TITLE
Update MCP docs with new tools and per-agent install paths

### DIFF
--- a/introduction/get-started/maestro-mcp.md
+++ b/introduction/get-started/maestro-mcp.md
@@ -155,7 +155,7 @@ See the [Copilot CLI MCP docs](https://docs.github.com/en/copilot/how-tos/copilo
 1. [Install the Maestro CLI](https://docs.maestro.dev/maestro-cli/how-to-install-maestro-cli).
 2. Install the MCP. The quickest option is the one-click button:
 
-    [![Install MCP Server](https://cursor.com/deeplink/mcp-install-dark.svg)](https://cursor.com/en-US/install-mcp?name=maestro&config=eyJjb21tYW5kIjoibWFlc3RybyBtY3AifQ%3D%3D)
+    <a href="https://cursor.com/en-US/install-mcp?name=maestro&config=eyJjb21tYW5kIjoibWFlc3RybyBtY3AifQ%3D%3D"><img src="https://cursor.com/deeplink/mcp-install-dark.svg" alt="Install MCP Server"></a>
 
     Or set it up manually: open **Cursor Settings → Tools & MCPs → Add Custom MCP**. Cursor opens `~/.cursor/mcp.json` for editing. Merge the following into it (or into a project-scoped `.cursor/mcp.json` in your repo root):
 

--- a/introduction/get-started/maestro-mcp.md
+++ b/introduction/get-started/maestro-mcp.md
@@ -160,8 +160,6 @@ See the [Copilot CLI MCP docs](https://docs.github.com/en/copilot/how-tos/copilo
     }
     ```
 
-On older Cursor versions, the equivalent UI path is **Cursor Settings → MCP → Add new MCP Server**. Name it `maestro`, choose the `command` type, and enter `maestro mcp` as the command.
-
 See the [Cursor MCP docs](https://cursor.com/docs/context/mcp) for more.
 
 </details>

--- a/introduction/get-started/maestro-mcp.md
+++ b/introduction/get-started/maestro-mcp.md
@@ -241,8 +241,6 @@ The Maestro MCP is bundled inside the Maestro CLI, so upgrading the CLI upgrades
 
 ## MCP tools
 
-Maestro's MCP server exposes the following tools. The server also ships instructions that guide the agent through the local (`list_devices → inspect_screen → run`) and Cloud (`list_cloud_devices → run_on_cloud → get_cloud_run_status`) workflows.
-
 ### Local
 
 | Tool              | Description                                                                                                                                                                                              |

--- a/introduction/get-started/maestro-mcp.md
+++ b/introduction/get-started/maestro-mcp.md
@@ -47,7 +47,7 @@ This assumes `maestro` is on your `PATH`. If it isn't, replace `"maestro"` with 
 
 <details>
 
-<summary><i class="fa-sparkles">:sparkles:</i> Claude Code CLI</summary>
+<summary>Claude Code CLI</summary>
 
 1. [Install the Maestro CLI](https://docs.maestro.dev/maestro-cli/how-to-install-maestro-cli).
 2. Run:
@@ -64,7 +64,7 @@ See the [Claude Code MCP docs](https://docs.claude.com/en/docs/claude-code/mcp) 
 
 <details>
 
-<summary><i class="fa-atom">:atom:</i> Codex</summary>
+<summary>Codex</summary>
 
 1. [Install the Maestro CLI](https://docs.maestro.dev/maestro-cli/how-to-install-maestro-cli).
 2. Run:
@@ -87,7 +87,7 @@ See the [Codex MCP docs](https://developers.openai.com/codex/mcp) and the [confi
 
 <details>
 
-<summary><i class="fa-desktop">:desktop:</i> Claude Desktop</summary>
+<summary>Claude Desktop</summary>
 
 1. [Install the Maestro CLI](https://docs.maestro.dev/maestro-cli/how-to-install-maestro-cli).
 2. In Claude Desktop, open **Settings → Developer → Edit Config** and merge the following into `claude_desktop_config.json`:
@@ -121,7 +121,7 @@ The **Connectors** UI in Claude Desktop only supports remote MCP servers that us
 
 <details>
 
-<summary><i class="fa-github">:github:</i> GitHub Copilot CLI</summary>
+<summary>GitHub Copilot CLI</summary>
 
 1. [Install the Maestro CLI](https://docs.maestro.dev/maestro-cli/how-to-install-maestro-cli).
 2. In a Copilot CLI session, run `/mcp add` and follow the interactive form with:
@@ -150,7 +150,7 @@ See the [Copilot CLI MCP docs](https://docs.github.com/en/copilot/how-tos/copilo
 
 <details>
 
-<summary><i class="fa-cube">:cube:</i> Cursor IDE</summary>
+<summary>Cursor IDE</summary>
 
 1. [Install the Maestro CLI](https://docs.maestro.dev/maestro-cli/how-to-install-maestro-cli).
 2. Install the MCP. The quickest option is the one-click button:
@@ -176,7 +176,7 @@ See the [Cursor MCP docs](https://cursor.com/docs/context/mcp) for more.
 
 <details>
 
-<summary><i class="fa-terminal">:terminal:</i> Cursor CLI</summary>
+<summary>Cursor CLI</summary>
 
 The Cursor CLI shares its MCP config with the Cursor IDE. If Maestro is already set up in the IDE, there's nothing else to do.
 
@@ -202,7 +202,7 @@ See the [Cursor CLI MCP docs](https://cursor.com/docs/cli/mcp).
 
 <details>
 
-<summary><i class="fa-gem">:gem:</i> Gemini CLI</summary>
+<summary>Gemini CLI</summary>
 
 1. [Install the Maestro CLI](https://docs.maestro.dev/maestro-cli/how-to-install-maestro-cli).
 2. Run:

--- a/introduction/get-started/maestro-mcp.md
+++ b/introduction/get-started/maestro-mcp.md
@@ -126,8 +126,7 @@ The **Connectors** UI in Claude Desktop only supports remote MCP servers that us
 
     * Name: `maestro`
     * Type: `local`
-    * Command: `maestro`
-    * Args: `mcp`
+    * Command: `maestro mcp`
 
     Or add to `~/.copilot/mcp-config.json` manually:
 

--- a/introduction/get-started/maestro-mcp.md
+++ b/introduction/get-started/maestro-mcp.md
@@ -104,7 +104,12 @@ See the [Codex MCP docs](https://developers.openai.com/codex/mcp) and the [confi
     }
     ```
 
-    The config file lives at `~/Library/Application Support/Claude/claude_desktop_config.json` on macOS or `%APPDATA%\Claude\claude_desktop_config.json` on Windows. Claude Desktop launches from a minimal shell, so pass `JAVA_HOME` explicitly and use the full path to the `maestro` binary.
+    The config file lives at:
+
+    * **macOS:** `~/Library/Application Support/Claude/claude_desktop_config.json`
+    * **Windows:** `%APPDATA%\Claude\claude_desktop_config.json`
+
+    Claude Desktop launches from a minimal shell, so pass `JAVA_HOME` explicitly and use the full path to the `maestro` binary (run `which maestro` in your terminal to find it).
 
 {% hint style="info" %}
 The **Connectors** UI in Claude Desktop only supports remote MCP servers that use OAuth. Local stdio servers like Maestro must be added by editing `claude_desktop_config.json` directly.

--- a/introduction/get-started/maestro-mcp.md
+++ b/introduction/get-started/maestro-mcp.md
@@ -87,6 +87,10 @@ See the [Codex MCP docs](https://developers.openai.com/codex/mcp) and the [confi
 
 <summary>Claude Desktop</summary>
 
+If you already added Maestro through the Claude Code CLI with user scope, Claude Desktop will pick it up automatically — no extra setup needed.
+
+Otherwise:
+
 1. [Install the Maestro CLI](../../maestro-cli/how-to-install-maestro-cli/README.md).
 2. Open **Settings → Developer → Edit Config** and merge the following into `claude_desktop_config.json`:
 

--- a/introduction/get-started/maestro-mcp.md
+++ b/introduction/get-started/maestro-mcp.md
@@ -56,7 +56,9 @@ This assumes `maestro` is on your `PATH`. If it isn't, replace `"maestro"` with 
     claude mcp add maestro -- maestro mcp
     ```
 
+{% hint style="info" %}
 See the [Claude Code MCP docs](https://docs.claude.com/en/docs/claude-code/mcp) for scope options (`--scope user`, `--scope project`, etc.).
+{% endhint %}
 
 </details>
 
@@ -218,7 +220,9 @@ See the [Cursor CLI MCP docs](https://cursor.com/docs/cli/mcp).
     }
     ```
 
-See the [Gemini CLI MCP docs](https://geminicli.com/docs/tools/mcp-server/) for scope options (`-s user` writes to `~/.gemini/settings.json`, `-s project` to `.gemini/settings.json`; default is `project`).
+{% hint style="info" %}
+See the [Gemini CLI MCP docs](https://geminicli.com/docs/tools/mcp-server/) for scope options (`-s user`, `-s project`, etc.).
+{% endhint %}
 
 </details>
 

--- a/introduction/get-started/maestro-mcp.md
+++ b/introduction/get-started/maestro-mcp.md
@@ -241,22 +241,17 @@ The Maestro MCP is bundled inside the Maestro CLI, so upgrading the CLI upgrades
 
 ## MCP tools
 
-### Local
+| Tool                   | Description                                                                                                                                                                                              |
+| ---------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `list_devices`         | List all available local devices (Android emulators, iOS simulators, and Chromium for web) that can be targeted for automation.                                                                           |
+| `inspect_screen`       | Get the current screen's view hierarchy as compact JSON. Call this before targeting elements, and re-call after any UI change.                                                                            |
+| `take_screenshot`      | Take a screenshot of the current device screen. Useful when a visual helps disambiguate elements.                                                                                                         |
+| `run`                  | Execute Maestro flows. Accepts exactly one of `{ yaml }` (inline YAML, preferred for exploration), `{ files }` (specific `.yaml` files), or `{ dir, include_tags, exclude_tags }`. Syntax is validated as part of the call. Replaces the old `run_flow` + `run_flow_files` pair and the imperative single-action tools. |
+| `cheat_sheet`          | Return the Maestro cheat sheet covering common commands, flow syntax, and best practices. The agent should call this before authoring unfamiliar commands.                                                |
+| `list_cloud_devices`   | List valid `{ device_model, device_os }` pairs available on Maestro Cloud. Call before `run_on_cloud` — OS versions must be passed verbatim (e.g. `iOS-17-5`, `android-34`).                               |
+| `run_on_cloud`         | Submit a flow (or folder of flows) to Maestro Cloud. Returns `upload_id`, `project_id`, and a dashboard URL immediately.                                                                                  |
+| `get_cloud_run_status` | Poll the status and per-flow results of a Cloud run. Poll every 60s until the status is terminal (`SUCCESS`, `ERROR`, `CANCELED`, `WARNING`).                                                             |
 
-| Tool              | Description                                                                                                                                                                                              |
-| ----------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `list_devices`    | List all available local devices (Android emulators, iOS simulators, and Chromium for web) that can be targeted for automation.                                                                           |
-| `inspect_screen`  | Get the current screen's view hierarchy as compact JSON. Call this before targeting elements, and re-call after any UI change.                                                                            |
-| `take_screenshot` | Take a screenshot of the current device screen. Useful when a visual helps disambiguate elements.                                                                                                         |
-| `run`             | Execute Maestro flows. Accepts exactly one of `{ yaml }` (inline YAML, preferred for exploration), `{ files }` (specific `.yaml` files), or `{ dir, include_tags, exclude_tags }`. Syntax is validated as part of the call. Replaces the old `run_flow` + `run_flow_files` pair and the imperative single-action tools. |
-| `cheat_sheet`     | Return the Maestro cheat sheet covering common commands, flow syntax, and best practices. The agent should call this before authoring unfamiliar commands.                                                |
-
-### Cloud
-
-| Tool                    | Description                                                                                                                                                                        |
-| ----------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `list_cloud_devices`    | List valid `{ device_model, device_os }` pairs available on Maestro Cloud. Call before `run_on_cloud` — OS versions must be passed verbatim (e.g. `iOS-17-5`, `android-34`).         |
-| `run_on_cloud`          | Submit a flow (or folder of flows) to Maestro Cloud. Returns `upload_id`, `project_id`, and a dashboard URL immediately.                                                            |
-| `get_cloud_run_status`  | Poll the status and per-flow results of a Cloud run. Poll every 60s until the status is terminal (`SUCCESS`, `ERROR`, `CANCELED`, `WARNING`).                                       |
-
-Cloud tools require Maestro Cloud authentication: run `maestro login` (recommended) or set `MAESTRO_CLOUD_API_KEY` for non-interactive environments.
+{% hint style="info" %}
+The `list_cloud_devices`, `run_on_cloud`, and `get_cloud_run_status` tools require Maestro Cloud authentication. Run `maestro login` (recommended) or set `MAESTRO_CLOUD_API_KEY` for non-interactive environments.
+{% endhint %}

--- a/introduction/get-started/maestro-mcp.md
+++ b/introduction/get-started/maestro-mcp.md
@@ -153,9 +153,9 @@ See the [Copilot CLI MCP docs](https://docs.github.com/en/copilot/how-tos/copilo
 <summary>Cursor IDE</summary>
 
 1. [Install the Maestro CLI](https://docs.maestro.dev/maestro-cli/how-to-install-maestro-cli).
-2. Install the MCP. The quickest option is the one-click deep link:
+2. Install the MCP. The quickest option is the one-click button:
 
-    [**Add Maestro to Cursor**](cursor://anysphere.cursor-deeplink/mcp/install?name=maestro&config=eyJjb21tYW5kIjoibWFlc3RybyBtY3AifQ%3D%3D)
+    [![Install MCP Server](https://cursor.com/deeplink/mcp-install-dark.svg)](https://cursor.com/en-US/install-mcp?name=maestro&config=eyJjb21tYW5kIjoibWFlc3RybyBtY3AifQ%3D%3D)
 
     Or set it up manually: open **Cursor Settings → Tools & MCPs → Add Custom MCP**. Cursor opens `~/.cursor/mcp.json` for editing. Merge the following into it (or into a project-scoped `.cursor/mcp.json` in your repo root):
 

--- a/introduction/get-started/maestro-mcp.md
+++ b/introduction/get-started/maestro-mcp.md
@@ -87,7 +87,7 @@ See the [Codex MCP docs](https://developers.openai.com/codex/mcp) and the [confi
 
 <summary>Claude Desktop</summary>
 
-If you already added Maestro through the Claude Code CLI with user scope, Claude Desktop will pick it up automatically — no extra setup needed.
+If you already added Maestro through the Claude Code CLI with user scope, Claude Desktop will pick it up automatically, so no extra setup is needed.
 
 Otherwise:
 
@@ -252,7 +252,7 @@ The Maestro MCP is bundled inside the Maestro CLI, so upgrading the CLI upgrades
 | `take_screenshot`      | Take a screenshot of the current device screen. Useful when a visual helps disambiguate elements.                                                                                                         |
 | `run`                  | Execute Maestro flows. Accepts exactly one of `{ yaml }` (inline YAML, preferred for exploration), `{ files }` (specific `.yaml` files), or `{ dir, include_tags, exclude_tags }`. Syntax is validated as part of the call. Replaces the old `run_flow` + `run_flow_files` pair and the imperative single-action tools. |
 | `cheat_sheet`          | Return the Maestro cheat sheet covering common commands, flow syntax, and best practices. The agent should call this before authoring unfamiliar commands.                                                |
-| `list_cloud_devices`   | List valid `{ device_model, device_os }` pairs available on Maestro Cloud. Call before `run_on_cloud` — OS versions must be passed verbatim (e.g. `iOS-17-5`, `android-34`).                               |
+| `list_cloud_devices`   | List valid `{ device_model, device_os }` pairs available on Maestro Cloud. Call before `run_on_cloud`. OS versions must be passed verbatim (e.g. `iOS-17-5`, `android-34`).                                |
 | `run_on_cloud`         | Submit a flow (or folder of flows) to Maestro Cloud. Returns `upload_id`, `project_id`, and a dashboard URL immediately.                                                                                  |
 | `get_cloud_run_status` | Poll the status and per-flow results of a Cloud run. Poll every 60s until the status is terminal (`SUCCESS`, `ERROR`, `CANCELED`, `WARNING`).                                                             |
 

--- a/introduction/get-started/maestro-mcp.md
+++ b/introduction/get-started/maestro-mcp.md
@@ -62,6 +62,29 @@ See the [Claude Code MCP docs](https://docs.claude.com/en/docs/claude-code/mcp) 
 
 <details>
 
+<summary>Codex</summary>
+
+1. [Install the Maestro CLI](../../maestro-cli/how-to-install-maestro-cli/README.md).
+2. Run:
+
+    ```bash
+    codex mcp add maestro -- maestro mcp
+    ```
+
+    Or add to `~/.codex/config.toml` manually:
+
+    ```toml
+    [mcp_servers.maestro]
+    command = "maestro"
+    args = ["mcp"]
+    ```
+
+See the [Codex MCP docs](https://developers.openai.com/codex/mcp) and the [config reference](https://developers.openai.com/codex/config-reference).
+
+</details>
+
+<details>
+
 <summary>Claude Desktop</summary>
 
 1. [Install the Maestro CLI](../../maestro-cli/how-to-install-maestro-cli/README.md).
@@ -82,6 +105,36 @@ See the [Claude Code MCP docs](https://docs.claude.com/en/docs/claude-code/mcp) 
     ```
 
     The config file lives at `~/Library/Application Support/Claude/claude_desktop_config.json` on macOS or `%APPDATA%\Claude\claude_desktop_config.json` on Windows. Claude Desktop launches from a minimal shell, so pass `JAVA_HOME` explicitly and use the full path to the `maestro` binary.
+
+</details>
+
+<details>
+
+<summary>GitHub Copilot CLI</summary>
+
+1. [Install the Maestro CLI](../../maestro-cli/how-to-install-maestro-cli/README.md).
+2. In a Copilot CLI session, run `/mcp add` and follow the interactive form with:
+
+    * Name: `maestro`
+    * Type: `stdio`
+    * Command: `maestro`
+    * Args: `mcp`
+
+    Or add to `~/.copilot/mcp-config.json` manually:
+
+    ```json
+    {
+        "mcpServers": {
+            "maestro": {
+                "type": "stdio",
+                "command": "maestro",
+                "args": ["mcp"]
+            }
+        }
+    }
+    ```
+
+See the [Copilot CLI MCP docs](https://docs.github.com/en/copilot/how-tos/copilot-cli/customize-copilot/add-mcp-servers).
 
 </details>
 
@@ -137,59 +190,6 @@ See the [Cursor CLI MCP docs](https://cursor.com/docs/cli/mcp).
 
 <details>
 
-<summary>GitHub Copilot CLI</summary>
-
-1. [Install the Maestro CLI](../../maestro-cli/how-to-install-maestro-cli/README.md).
-2. In a Copilot CLI session, run `/mcp add` and follow the interactive form with:
-
-    * Name: `maestro`
-    * Type: `stdio`
-    * Command: `maestro`
-    * Args: `mcp`
-
-    Or add to `~/.copilot/mcp-config.json` manually:
-
-    ```json
-    {
-        "mcpServers": {
-            "maestro": {
-                "type": "stdio",
-                "command": "maestro",
-                "args": ["mcp"]
-            }
-        }
-    }
-    ```
-
-See the [Copilot CLI MCP docs](https://docs.github.com/en/copilot/how-tos/copilot-cli/customize-copilot/add-mcp-servers).
-
-</details>
-
-<details>
-
-<summary>Codex</summary>
-
-1. [Install the Maestro CLI](../../maestro-cli/how-to-install-maestro-cli/README.md).
-2. Run:
-
-    ```bash
-    codex mcp add maestro -- maestro mcp
-    ```
-
-    Or add to `~/.codex/config.toml` manually:
-
-    ```toml
-    [mcp_servers.maestro]
-    command = "maestro"
-    args = ["mcp"]
-    ```
-
-See the [Codex MCP docs](https://developers.openai.com/codex/mcp) and the [config reference](https://developers.openai.com/codex/config-reference).
-
-</details>
-
-<details>
-
 <summary>Gemini CLI</summary>
 
 1. [Install the Maestro CLI](../../maestro-cli/how-to-install-maestro-cli/README.md).
@@ -232,11 +232,11 @@ The Maestro MCP is bundled inside the Maestro CLI, so upgrading the CLI upgrades
 | Agent                | How to reload                                                                  |
 | -------------------- | ------------------------------------------------------------------------------ |
 | Claude Code CLI      | Run `/mcp`, select **maestro**, then **Reconnect**.                            |
+| Codex                | Restart the Codex CLI.                                                         |
 | Claude Desktop       | Restart Claude Desktop.                                                        |
+| GitHub Copilot CLI   | Restart the Copilot CLI.                                                       |
 | Cursor IDE           | **Cursor Settings → MCP → Restart** the Maestro server, or restart Cursor.     |
 | Cursor CLI           | Restart `cursor-agent`. No in-session reload command exists.                   |
-| GitHub Copilot CLI   | Restart the Copilot CLI.                                                       |
-| Codex                | Restart the Codex CLI.                                                         |
 | Gemini CLI           | Restart the Gemini CLI.                                                        |
 
 ## MCP tools

--- a/introduction/get-started/maestro-mcp.md
+++ b/introduction/get-started/maestro-mcp.md
@@ -87,12 +87,8 @@ See the [Codex MCP docs](https://developers.openai.com/codex/mcp) and the [confi
 
 <summary>Claude Desktop</summary>
 
-If you already added Maestro through the Claude Code CLI with user scope, Claude Desktop will pick it up automatically, so no extra setup is needed.
-
-Otherwise:
-
 1. [Install the Maestro CLI](../../maestro-cli/how-to-install-maestro-cli/README.md).
-2. Open **Settings → Developer → Edit Config** and merge the following into `claude_desktop_config.json`:
+2. In Claude Desktop, open **Settings → Developer → Edit Config** and merge the following into `claude_desktop_config.json`:
 
     ```json
     {
@@ -109,6 +105,10 @@ Otherwise:
     ```
 
     The config file lives at `~/Library/Application Support/Claude/claude_desktop_config.json` on macOS or `%APPDATA%\Claude\claude_desktop_config.json` on Windows. Claude Desktop launches from a minimal shell, so pass `JAVA_HOME` explicitly and use the full path to the `maestro` binary.
+
+{% hint style="info" %}
+The **Connectors** UI in Claude Desktop only supports remote MCP servers that use OAuth. Local stdio servers like Maestro must be added by editing `claude_desktop_config.json` directly.
+{% endhint %}
 
 </details>
 

--- a/introduction/get-started/maestro-mcp.md
+++ b/introduction/get-started/maestro-mcp.md
@@ -253,19 +253,21 @@ The Maestro MCP is bundled inside the Maestro CLI, so upgrading the CLI upgrades
 | Cursor CLI           | Restart `cursor-agent`. No in-session reload command exists.                   |
 | Gemini CLI           | Restart the Gemini CLI.                                                        |
 
-## MCP tools
+## MCP commands
 
-| Tool                   | Description                                                                                                                                                                                              |
-| ---------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `list_devices`         | List all available local devices (Android emulators, iOS simulators, and Chromium for web) that can be targeted for automation.                                                                           |
-| `inspect_screen`       | Get the current screen's view hierarchy as compact JSON. Call this before targeting elements, and re-call after any UI change.                                                                            |
-| `take_screenshot`      | Take a screenshot of the current device screen. Useful when a visual helps disambiguate elements.                                                                                                         |
-| `run`                  | Execute Maestro flows. Accepts exactly one of `{ yaml }` (inline YAML, preferred for exploration), `{ files }` (specific `.yaml` files), or `{ dir, include_tags, exclude_tags }`. Syntax is validated as part of the call. Replaces the old `run_flow` + `run_flow_files` pair and the imperative single-action tools. |
-| `cheat_sheet`          | Return the Maestro cheat sheet covering common commands, flow syntax, and best practices. The agent should call this before authoring unfamiliar commands.                                                |
-| `list_cloud_devices`   | List valid `{ device_model, device_os }` pairs available on Maestro Cloud. Call before `run_on_cloud`. OS versions must be passed verbatim (e.g. `iOS-17-5`, `android-34`).                                |
-| `run_on_cloud`         | Submit a flow (or folder of flows) to Maestro Cloud. Returns `upload_id`, `project_id`, and a dashboard URL immediately.                                                                                  |
-| `get_cloud_run_status` | Poll the status and per-flow results of a Cloud run. Poll every 60s until the status is terminal (`SUCCESS`, `ERROR`, `CANCELED`, `WARNING`).                                                             |
-
-{% hint style="info" %}
-The `list_cloud_devices`, `run_on_cloud`, and `get_cloud_run_status` tools require Maestro Cloud authentication. Run `maestro login` (recommended) or set `MAESTRO_CLOUD_API_KEY` for non-interactive environments.
-{% endhint %}
+| Command                  | Description                                                            |
+| ------------------------ | ---------------------------------------------------------------------- |
+| `back`                   | Press the back button.                                                 |
+| `cheat_sheet`            | Get the Maestro cheat sheet with common commands and syntax examples.  |
+| `check_flow_syntax`      | Validates the syntax of a flow.                                        |
+| `input_text`             | Input text to the current focused text field.                          |
+| `inspect_view_hierarchy` | Get the nested views hierarchy of the current screen in CSV format.    |
+| `launch_app`             | Launch an app on the connected device.                                 |
+| `list_devices`           | List all devices.                                                      |
+| `query_docs`             | Query the Maestro documentation for specific information.              |
+| `run_flow`               | Run a flow.                                                            |
+| `run_flow_files`         | Run one or more full Maestro flows.                                    |
+| `start_device`           | Start a device like a simulator or emulator and returns the device ID. |
+| `stop_app`               | Stop an app on the connected device.                                   |
+| `take_screenshot`        | Take a screenshot of the current device screen.                        |
+| `tap_on`                 | Tap on a UI element using the selector description.                    |

--- a/introduction/get-started/maestro-mcp.md
+++ b/introduction/get-started/maestro-mcp.md
@@ -65,38 +65,23 @@ See the [Claude Code MCP docs](https://docs.claude.com/en/docs/claude-code/mcp) 
 <summary>Claude Desktop</summary>
 
 1. [Install the Maestro CLI](../../maestro-cli/how-to-install-maestro-cli/README.md).
-2. Add Maestro to Claude Desktop's config.
+2. Open **Settings → Developer → Edit Config** and merge the following into `claude_desktop_config.json`:
 
-{% tabs %}
-{% tab title="Prompt" %}
-In a Claude Desktop Code tab, prompt:
-
-```
-update claude_desktop_config.json to add the maestro mcp server:
-"maestro": { "command": "<full path to maestro>", "args": ["mcp"], "env": { <include JAVA_HOME> } }
-```
-{% endtab %}
-
-{% tab title="Manual" %}
-Open **Settings → Developer → Edit Config** and merge:
-
-```json
-{
-    "mcpServers": {
-        "maestro": {
-            "command": "<full path to maestro binary>",
-            "args": ["mcp"],
-            "env": {
-                "JAVA_HOME": "<full JAVA_HOME directory>"
+    ```json
+    {
+        "mcpServers": {
+            "maestro": {
+                "command": "<full path to maestro binary>",
+                "args": ["mcp"],
+                "env": {
+                    "JAVA_HOME": "<full JAVA_HOME directory>"
+                }
             }
         }
     }
-}
-```
+    ```
 
-The config file lives at `~/Library/Application Support/Claude/claude_desktop_config.json` on macOS or `%APPDATA%\Claude\claude_desktop_config.json` on Windows. Claude Desktop launches from a minimal shell, so pass `JAVA_HOME` explicitly and use the full path to the `maestro` binary.
-{% endtab %}
-{% endtabs %}
+    The config file lives at `~/Library/Application Support/Claude/claude_desktop_config.json` on macOS or `%APPDATA%\Claude\claude_desktop_config.json` on Windows. Claude Desktop launches from a minimal shell, so pass `JAVA_HOME` explicitly and use the full path to the `maestro` binary.
 
 </details>
 
@@ -133,35 +118,20 @@ The Cursor CLI shares its MCP config with the Cursor IDE. If Maestro is already 
 Otherwise:
 
 1. [Install the Maestro CLI](../../maestro-cli/how-to-install-maestro-cli/README.md).
-2. Add Maestro to `.cursor/mcp.json`.
+2. Add Maestro to `.cursor/mcp.json` in your project root:
 
-{% tabs %}
-{% tab title="Prompt" %}
-In a cursor-agent session, prompt:
-
-```
-update .cursor/mcp.json to add the maestro mcp server:
-"maestro": { "command": "maestro", "args": ["mcp"] }
-```
-{% endtab %}
-
-{% tab title="Manual" %}
-Add to `.cursor/mcp.json` in your project root:
-
-```json
-{
-    "mcpServers": {
-        "maestro": {
-            "command": "maestro",
-            "args": ["mcp"]
+    ```json
+    {
+        "mcpServers": {
+            "maestro": {
+                "command": "maestro",
+                "args": ["mcp"]
+            }
         }
     }
-}
-```
+    ```
 
 See the [Cursor CLI MCP docs](https://cursor.com/docs/cli/mcp).
-{% endtab %}
-{% endtabs %}
 
 </details>
 
@@ -170,36 +140,28 @@ See the [Cursor CLI MCP docs](https://cursor.com/docs/cli/mcp).
 <summary>GitHub Copilot CLI</summary>
 
 1. [Install the Maestro CLI](../../maestro-cli/how-to-install-maestro-cli/README.md).
-2. Add Maestro to Copilot CLI.
+2. In a Copilot CLI session, run `/mcp add` and follow the interactive form with:
 
-{% tabs %}
-{% tab title="Prompt" %}
-In a Copilot CLI session, run `/mcp add` and follow the interactive form:
+    * Name: `maestro`
+    * Type: `stdio`
+    * Command: `maestro`
+    * Args: `mcp`
 
-* Name: `maestro`
-* Type: `stdio`
-* Command: `maestro`
-* Args: `mcp`
+    Or add to `~/.copilot/mcp-config.json` manually:
 
-See the [Copilot CLI MCP docs](https://docs.github.com/en/copilot/how-tos/copilot-cli/customize-copilot/add-mcp-servers).
-{% endtab %}
-
-{% tab title="Manual" %}
-Add to `~/.copilot/mcp-config.json`:
-
-```json
-{
-    "mcpServers": {
-        "maestro": {
-            "type": "stdio",
-            "command": "maestro",
-            "args": ["mcp"]
+    ```json
+    {
+        "mcpServers": {
+            "maestro": {
+                "type": "stdio",
+                "command": "maestro",
+                "args": ["mcp"]
+            }
         }
     }
-}
-```
-{% endtab %}
-{% endtabs %}
+    ```
+
+See the [Copilot CLI MCP docs](https://docs.github.com/en/copilot/how-tos/copilot-cli/customize-copilot/add-mcp-servers).
 
 </details>
 
@@ -208,31 +170,21 @@ Add to `~/.copilot/mcp-config.json`:
 <summary>Codex</summary>
 
 1. [Install the Maestro CLI](../../maestro-cli/how-to-install-maestro-cli/README.md).
-2. Add Maestro to Codex.
+2. Run:
 
-{% tabs %}
-{% tab title="Prompt" %}
-Run:
+    ```bash
+    codex mcp add maestro -- maestro mcp
+    ```
 
-```bash
-codex mcp add maestro -- maestro mcp
-```
+    Or add to `~/.codex/config.toml` manually:
 
-See the [Codex MCP docs](https://developers.openai.com/codex/mcp).
-{% endtab %}
+    ```toml
+    [mcp_servers.maestro]
+    command = "maestro"
+    args = ["mcp"]
+    ```
 
-{% tab title="Manual" %}
-Add to `~/.codex/config.toml`:
-
-```toml
-[mcp_servers.maestro]
-command = "maestro"
-args = ["mcp"]
-```
-
-See the [Codex config reference](https://developers.openai.com/codex/config-reference).
-{% endtab %}
-{% endtabs %}
+See the [Codex MCP docs](https://developers.openai.com/codex/mcp) and the [config reference](https://developers.openai.com/codex/config-reference).
 
 </details>
 
@@ -241,34 +193,26 @@ See the [Codex config reference](https://developers.openai.com/codex/config-refe
 <summary>Gemini CLI</summary>
 
 1. [Install the Maestro CLI](../../maestro-cli/how-to-install-maestro-cli/README.md).
-2. Add Maestro to Gemini CLI.
+2. Run:
 
-{% tabs %}
-{% tab title="Prompt" %}
-Run:
+    ```bash
+    gemini mcp add maestro maestro mcp
+    ```
 
-```bash
-gemini mcp add maestro maestro mcp
-```
+    Or add to `~/.gemini/settings.json` manually:
 
-See the [Gemini CLI MCP docs](https://geminicli.com/docs/tools/mcp-server/).
-{% endtab %}
-
-{% tab title="Manual" %}
-Add to `~/.gemini/settings.json`:
-
-```json
-{
-    "mcpServers": {
-        "maestro": {
-            "command": "maestro",
-            "args": ["mcp"]
+    ```json
+    {
+        "mcpServers": {
+            "maestro": {
+                "command": "maestro",
+                "args": ["mcp"]
+            }
         }
     }
-}
-```
-{% endtab %}
-{% endtabs %}
+    ```
+
+See the [Gemini CLI MCP docs](https://geminicli.com/docs/tools/mcp-server/).
 
 </details>
 

--- a/introduction/get-started/maestro-mcp.md
+++ b/introduction/get-started/maestro-mcp.md
@@ -147,22 +147,22 @@ See the [Copilot CLI MCP docs](https://docs.github.com/en/copilot/how-tos/copilo
 <summary>Cursor IDE</summary>
 
 1. [Install the Maestro CLI](../../maestro-cli/how-to-install-maestro-cli/README.md).
-2. Open **Cursor Settings → MCP → Add new MCP Server**. Name it `maestro`, choose the `command` type, and enter `maestro mcp` as the command.
+2. Add Maestro to `.cursor/mcp.json` (project scope) or `~/.cursor/mcp.json` (global scope):
 
-Alternatively, add to `.cursor/mcp.json` in your project root:
-
-```json
-{
-    "mcpServers": {
-        "maestro": {
-            "command": "maestro",
-            "args": ["mcp"]
+    ```json
+    {
+        "mcpServers": {
+            "maestro": {
+                "command": "maestro",
+                "args": ["mcp"]
+            }
         }
     }
-}
-```
+    ```
 
-See the [Cursor MCP docs](https://cursor.com/docs/context/mcp#installing-mcp-servers) for more.
+3. Open **Cursor Settings → Features → Model Context Protocol** to confirm the `maestro` server is toggled on.
+
+See the [Cursor MCP docs](https://cursor.com/docs/context/mcp) for more.
 
 </details>
 

--- a/introduction/get-started/maestro-mcp.md
+++ b/introduction/get-started/maestro-mcp.md
@@ -45,180 +45,175 @@ If your agent isn't listed below, the generic stdio config is:
 This assumes `maestro` is on your `PATH`. If it isn't, replace `"maestro"` with the full path to the Maestro CLI executable (e.g. `/opt/homebrew/bin/maestro`).
 {% endhint %}
 
-<details>
+### Claude Code CLI
 
-<summary>Claude Code CLI</summary>
+After [installing the Maestro CLI](../../maestro-cli/how-to-install-maestro-cli/README.md), run:
 
-1. [Install the Maestro CLI](../../maestro-cli/how-to-install-maestro-cli/README.md).
-2. Run:
-
-    ```bash
-    claude mcp add maestro -- maestro mcp
-    ```
+```bash
+claude mcp add maestro -- maestro mcp
+```
 
 See the [Claude Code MCP docs](https://docs.claude.com/en/docs/claude-code/mcp) for scope options (`--scope user`, `--scope project`, etc.).
 
-</details>
+### Codex
 
-<details>
+After [installing the Maestro CLI](../../maestro-cli/how-to-install-maestro-cli/README.md):
 
-<summary>Codex</summary>
+{% tabs %}
+{% tab title="Prompt" %}
+Run:
 
-1. [Install the Maestro CLI](../../maestro-cli/how-to-install-maestro-cli/README.md).
-2. Run:
+```bash
+codex mcp add maestro -- maestro mcp
+```
+{% endtab %}
 
-    ```bash
-    codex mcp add maestro -- maestro mcp
-    ```
+{% tab title="Install Manually" %}
+Add to `~/.codex/config.toml`:
 
-    Or add to `~/.codex/config.toml` manually:
-
-    ```toml
-    [mcp_servers.maestro]
-    command = "maestro"
-    args = ["mcp"]
-    ```
+```toml
+[mcp_servers.maestro]
+command = "maestro"
+args = ["mcp"]
+```
+{% endtab %}
+{% endtabs %}
 
 See the [Codex MCP docs](https://developers.openai.com/codex/mcp) and the [config reference](https://developers.openai.com/codex/config-reference).
 
-</details>
-
-<details>
-
-<summary>Claude Desktop</summary>
+### Claude Desktop
 
 If you already added Maestro through the Claude Code CLI with user scope, Claude Desktop will pick it up automatically, so no extra setup is needed.
 
-Otherwise:
+Otherwise, after [installing the Maestro CLI](../../maestro-cli/how-to-install-maestro-cli/README.md), open **Settings → Developer → Edit Config** and merge the following into `claude_desktop_config.json`:
 
-1. [Install the Maestro CLI](../../maestro-cli/how-to-install-maestro-cli/README.md).
-2. Open **Settings → Developer → Edit Config** and merge the following into `claude_desktop_config.json`:
-
-    ```json
-    {
-        "mcpServers": {
-            "maestro": {
-                "command": "<full path to maestro binary>",
-                "args": ["mcp"],
-                "env": {
-                    "JAVA_HOME": "<full JAVA_HOME directory>"
-                }
+```json
+{
+    "mcpServers": {
+        "maestro": {
+            "command": "<full path to maestro binary>",
+            "args": ["mcp"],
+            "env": {
+                "JAVA_HOME": "<full JAVA_HOME directory>"
             }
         }
     }
-    ```
+}
+```
 
-    The config file lives at `~/Library/Application Support/Claude/claude_desktop_config.json` on macOS or `%APPDATA%\Claude\claude_desktop_config.json` on Windows. Claude Desktop launches from a minimal shell, so pass `JAVA_HOME` explicitly and use the full path to the `maestro` binary.
+The config file lives at `~/Library/Application Support/Claude/claude_desktop_config.json` on macOS or `%APPDATA%\Claude\claude_desktop_config.json` on Windows. Claude Desktop launches from a minimal shell, so pass `JAVA_HOME` explicitly and use the full path to the `maestro` binary.
 
-</details>
+### GitHub Copilot CLI
 
-<details>
+After [installing the Maestro CLI](../../maestro-cli/how-to-install-maestro-cli/README.md):
 
-<summary>GitHub Copilot CLI</summary>
+{% tabs %}
+{% tab title="Prompt" %}
+In a Copilot CLI session, run `/mcp add` and follow the interactive form:
 
-1. [Install the Maestro CLI](../../maestro-cli/how-to-install-maestro-cli/README.md).
-2. In a Copilot CLI session, run `/mcp add` and follow the interactive form with:
+* Name: `maestro`
+* Type: `local`
+* Command: `maestro`
+* Args: `mcp`
+{% endtab %}
 
-    * Name: `maestro`
-    * Type: `stdio`
-    * Command: `maestro`
-    * Args: `mcp`
+{% tab title="Install Manually" %}
+Add to `~/.copilot/mcp-config.json`:
 
-    Or add to `~/.copilot/mcp-config.json` manually:
-
-    ```json
-    {
-        "mcpServers": {
-            "maestro": {
-                "type": "local",
-                "command": "maestro",
-                "args": ["mcp"]
-            }
+```json
+{
+    "mcpServers": {
+        "maestro": {
+            "type": "local",
+            "command": "maestro",
+            "args": ["mcp"]
         }
     }
-    ```
+}
+```
+{% endtab %}
+{% endtabs %}
 
 See the [Copilot CLI MCP docs](https://docs.github.com/en/copilot/how-tos/copilot-cli/customize-copilot/add-mcp-servers).
 
-</details>
+### Cursor IDE
 
-<details>
+After [installing the Maestro CLI](../../maestro-cli/how-to-install-maestro-cli/README.md):
 
-<summary>Cursor IDE</summary>
+{% tabs %}
+{% tab title="Cursor 3 (config file)" %}
+Add Maestro to `.cursor/mcp.json` (project scope) or `~/.cursor/mcp.json` (global scope):
 
-1. [Install the Maestro CLI](../../maestro-cli/how-to-install-maestro-cli/README.md).
-2. Add Maestro to `.cursor/mcp.json` (project scope) or `~/.cursor/mcp.json` (global scope):
-
-    ```json
-    {
-        "mcpServers": {
-            "maestro": {
-                "command": "maestro",
-                "args": ["mcp"]
-            }
+```json
+{
+    "mcpServers": {
+        "maestro": {
+            "command": "maestro",
+            "args": ["mcp"]
         }
     }
-    ```
+}
+```
 
-3. Open **Cursor Settings → Features → Model Context Protocol** to confirm the `maestro` server is toggled on.
+Open **Cursor Settings → Features → Model Context Protocol** to confirm the `maestro` server is toggled on.
+{% endtab %}
+
+{% tab title="Classic UI" %}
+On older Cursor versions, go to **Cursor Settings → MCP → Add new MCP Server**. Name it `maestro`, choose the `command` type, and enter `maestro mcp` as the command.
+{% endtab %}
+{% endtabs %}
 
 See the [Cursor MCP docs](https://cursor.com/docs/context/mcp) for more.
 
-</details>
-
-<details>
-
-<summary>Cursor CLI</summary>
+### Cursor CLI
 
 The Cursor CLI shares its MCP config with the Cursor IDE. If Maestro is already set up in the IDE, there's nothing else to do.
 
-Otherwise:
+Otherwise, after [installing the Maestro CLI](../../maestro-cli/how-to-install-maestro-cli/README.md), add Maestro to `.cursor/mcp.json` in your project root:
 
-1. [Install the Maestro CLI](../../maestro-cli/how-to-install-maestro-cli/README.md).
-2. Add Maestro to `.cursor/mcp.json` in your project root:
-
-    ```json
-    {
-        "mcpServers": {
-            "maestro": {
-                "command": "maestro",
-                "args": ["mcp"]
-            }
+```json
+{
+    "mcpServers": {
+        "maestro": {
+            "command": "maestro",
+            "args": ["mcp"]
         }
     }
-    ```
+}
+```
 
 See the [Cursor CLI MCP docs](https://cursor.com/docs/cli/mcp).
 
-</details>
+### Gemini CLI
 
-<details>
+After [installing the Maestro CLI](../../maestro-cli/how-to-install-maestro-cli/README.md):
 
-<summary>Gemini CLI</summary>
+{% tabs %}
+{% tab title="Prompt" %}
+Run:
 
-1. [Install the Maestro CLI](../../maestro-cli/how-to-install-maestro-cli/README.md).
-2. Run:
+```bash
+gemini mcp add maestro maestro mcp
+```
+{% endtab %}
 
-    ```bash
-    gemini mcp add maestro maestro mcp
-    ```
+{% tab title="Install Manually" %}
+Add to `~/.gemini/settings.json`:
 
-    Or add to `~/.gemini/settings.json` manually:
-
-    ```json
-    {
-        "mcpServers": {
-            "maestro": {
-                "command": "maestro",
-                "args": ["mcp"]
-            }
+```json
+{
+    "mcpServers": {
+        "maestro": {
+            "command": "maestro",
+            "args": ["mcp"]
         }
     }
-    ```
+}
+```
+{% endtab %}
+{% endtabs %}
 
 See the [Gemini CLI MCP docs](https://geminicli.com/docs/tools/mcp-server/).
-
-</details>
 
 **For other IDEs, use the generic stdio config above and consult their documentation:**
 

--- a/introduction/get-started/maestro-mcp.md
+++ b/introduction/get-started/maestro-mcp.md
@@ -245,7 +245,7 @@ The Maestro MCP is bundled inside the Maestro CLI, so upgrading the CLI upgrades
 | Codex                | Restart the Codex CLI.                                                         |
 | Claude Desktop       | Restart Claude Desktop.                                                        |
 | GitHub Copilot CLI   | Restart the Copilot CLI.                                                       |
-| Cursor IDE           | **Cursor Settings → MCP → Restart** the Maestro server, or restart Cursor.     |
+| Cursor IDE           | **Cursor Settings → Tools & MCPs** and toggle the Maestro server off and on, or restart Cursor. |
 | Cursor CLI           | Restart `cursor-agent`. No in-session reload command exists.                   |
 | Gemini CLI           | Restart the Gemini CLI.                                                        |
 

--- a/introduction/get-started/maestro-mcp.md
+++ b/introduction/get-started/maestro-mcp.md
@@ -18,14 +18,14 @@ The Maestro MCP server ships inside the Maestro CLI and exposes Maestro's author
 
 ## Prerequisites
 
-* The [Maestro CLI](../../maestro-cli/how-to-install-maestro-cli/README.md) installed and available on your `PATH`.
+* The [Maestro CLI](https://docs.maestro.dev/maestro-cli/how-to-install-maestro-cli) installed and available on your `PATH`.
 * A coding agent that supports MCP (see the install paths below).
 
 ## Install the Maestro MCP server on your coding agent
 
 Installing the Maestro MCP takes two steps:
 
-1. [Install the Maestro CLI](../../maestro-cli/how-to-install-maestro-cli/README.md) (via the curl script or Homebrew).
+1. [Install the Maestro CLI](https://docs.maestro.dev/maestro-cli/how-to-install-maestro-cli) (via the curl script or Homebrew).
 2. Register the Maestro MCP with your coding agent, using either the agent's one-line install command or a manual JSON/TOML config.
 
 If your agent isn't listed below, the generic stdio config is:
@@ -49,7 +49,7 @@ This assumes `maestro` is on your `PATH`. If it isn't, replace `"maestro"` with 
 
 <summary>Claude Code CLI</summary>
 
-1. [Install the Maestro CLI](../../maestro-cli/how-to-install-maestro-cli/README.md).
+1. [Install the Maestro CLI](https://docs.maestro.dev/maestro-cli/how-to-install-maestro-cli).
 2. Run:
 
     ```bash
@@ -66,7 +66,7 @@ See the [Claude Code MCP docs](https://docs.claude.com/en/docs/claude-code/mcp) 
 
 <summary>Codex</summary>
 
-1. [Install the Maestro CLI](../../maestro-cli/how-to-install-maestro-cli/README.md).
+1. [Install the Maestro CLI](https://docs.maestro.dev/maestro-cli/how-to-install-maestro-cli).
 2. Run:
 
     ```bash
@@ -89,7 +89,7 @@ See the [Codex MCP docs](https://developers.openai.com/codex/mcp) and the [confi
 
 <summary>Claude Desktop</summary>
 
-1. [Install the Maestro CLI](../../maestro-cli/how-to-install-maestro-cli/README.md).
+1. [Install the Maestro CLI](https://docs.maestro.dev/maestro-cli/how-to-install-maestro-cli).
 2. In Claude Desktop, open **Settings → Developer → Edit Config** and merge the following into `claude_desktop_config.json`:
 
     ```json
@@ -123,7 +123,7 @@ The **Connectors** UI in Claude Desktop only supports remote MCP servers that us
 
 <summary>GitHub Copilot CLI</summary>
 
-1. [Install the Maestro CLI](../../maestro-cli/how-to-install-maestro-cli/README.md).
+1. [Install the Maestro CLI](https://docs.maestro.dev/maestro-cli/how-to-install-maestro-cli).
 2. In a Copilot CLI session, run `/mcp add` and follow the interactive form with:
 
     * Name: `maestro`
@@ -152,7 +152,7 @@ See the [Copilot CLI MCP docs](https://docs.github.com/en/copilot/how-tos/copilo
 
 <summary>Cursor IDE</summary>
 
-1. [Install the Maestro CLI](../../maestro-cli/how-to-install-maestro-cli/README.md).
+1. [Install the Maestro CLI](https://docs.maestro.dev/maestro-cli/how-to-install-maestro-cli).
 2. Open **Cursor Settings → Tools & MCPs → Add Custom MCP**. Cursor opens `~/.cursor/mcp.json` for editing. Merge the following into it (or into a project-scoped `.cursor/mcp.json` in your repo root):
 
     ```json
@@ -178,7 +178,7 @@ The Cursor CLI shares its MCP config with the Cursor IDE. If Maestro is already 
 
 Otherwise:
 
-1. [Install the Maestro CLI](../../maestro-cli/how-to-install-maestro-cli/README.md).
+1. [Install the Maestro CLI](https://docs.maestro.dev/maestro-cli/how-to-install-maestro-cli).
 2. Add Maestro to `.cursor/mcp.json` in your project root:
 
     ```json
@@ -200,7 +200,7 @@ See the [Cursor CLI MCP docs](https://cursor.com/docs/cli/mcp).
 
 <summary>Gemini CLI</summary>
 
-1. [Install the Maestro CLI](../../maestro-cli/how-to-install-maestro-cli/README.md).
+1. [Install the Maestro CLI](https://docs.maestro.dev/maestro-cli/how-to-install-maestro-cli).
 2. Run:
 
     ```bash
@@ -236,7 +236,7 @@ See the [Gemini CLI MCP docs](https://geminicli.com/docs/tools/mcp-server/) for 
 
 The Maestro MCP is bundled inside the Maestro CLI, so upgrading the CLI upgrades the MCP server. After upgrading, your agent needs to reload the MCP connection to pick up the new binary.
 
-1. [Update the Maestro CLI](../../maestro-cli/how-to-install-maestro-cli/update-the-maestro-cli.md).
+1. [Update the Maestro CLI](https://docs.maestro.dev/maestro-cli/how-to-install-maestro-cli/update-the-maestro-cli).
 2. Reload the Maestro MCP in your agent:
 
 | Agent                | How to reload                                                                  |

--- a/introduction/get-started/maestro-mcp.md
+++ b/introduction/get-started/maestro-mcp.md
@@ -45,175 +45,182 @@ If your agent isn't listed below, the generic stdio config is:
 This assumes `maestro` is on your `PATH`. If it isn't, replace `"maestro"` with the full path to the Maestro CLI executable (e.g. `/opt/homebrew/bin/maestro`).
 {% endhint %}
 
-### Claude Code CLI
+<details>
 
-After [installing the Maestro CLI](../../maestro-cli/how-to-install-maestro-cli/README.md), run:
+<summary>Claude Code CLI</summary>
 
-```bash
-claude mcp add maestro -- maestro mcp
-```
+1. [Install the Maestro CLI](../../maestro-cli/how-to-install-maestro-cli/README.md).
+2. Run:
+
+    ```bash
+    claude mcp add maestro -- maestro mcp
+    ```
 
 See the [Claude Code MCP docs](https://docs.claude.com/en/docs/claude-code/mcp) for scope options (`--scope user`, `--scope project`, etc.).
 
-### Codex
+</details>
 
-After [installing the Maestro CLI](../../maestro-cli/how-to-install-maestro-cli/README.md):
+<details>
 
-{% tabs %}
-{% tab title="Prompt" %}
-Run:
+<summary>Codex</summary>
 
-```bash
-codex mcp add maestro -- maestro mcp
-```
-{% endtab %}
+1. [Install the Maestro CLI](../../maestro-cli/how-to-install-maestro-cli/README.md).
+2. Run:
 
-{% tab title="Install Manually" %}
-Add to `~/.codex/config.toml`:
+    ```bash
+    codex mcp add maestro -- maestro mcp
+    ```
 
-```toml
-[mcp_servers.maestro]
-command = "maestro"
-args = ["mcp"]
-```
-{% endtab %}
-{% endtabs %}
+    Or add to `~/.codex/config.toml` manually:
+
+    ```toml
+    [mcp_servers.maestro]
+    command = "maestro"
+    args = ["mcp"]
+    ```
 
 See the [Codex MCP docs](https://developers.openai.com/codex/mcp) and the [config reference](https://developers.openai.com/codex/config-reference).
 
-### Claude Desktop
+</details>
+
+<details>
+
+<summary>Claude Desktop</summary>
 
 If you already added Maestro through the Claude Code CLI with user scope, Claude Desktop will pick it up automatically, so no extra setup is needed.
 
-Otherwise, after [installing the Maestro CLI](../../maestro-cli/how-to-install-maestro-cli/README.md), open **Settings → Developer → Edit Config** and merge the following into `claude_desktop_config.json`:
+Otherwise:
 
-```json
-{
-    "mcpServers": {
-        "maestro": {
-            "command": "<full path to maestro binary>",
-            "args": ["mcp"],
-            "env": {
-                "JAVA_HOME": "<full JAVA_HOME directory>"
+1. [Install the Maestro CLI](../../maestro-cli/how-to-install-maestro-cli/README.md).
+2. Open **Settings → Developer → Edit Config** and merge the following into `claude_desktop_config.json`:
+
+    ```json
+    {
+        "mcpServers": {
+            "maestro": {
+                "command": "<full path to maestro binary>",
+                "args": ["mcp"],
+                "env": {
+                    "JAVA_HOME": "<full JAVA_HOME directory>"
+                }
             }
         }
     }
-}
-```
+    ```
 
-The config file lives at `~/Library/Application Support/Claude/claude_desktop_config.json` on macOS or `%APPDATA%\Claude\claude_desktop_config.json` on Windows. Claude Desktop launches from a minimal shell, so pass `JAVA_HOME` explicitly and use the full path to the `maestro` binary.
+    The config file lives at `~/Library/Application Support/Claude/claude_desktop_config.json` on macOS or `%APPDATA%\Claude\claude_desktop_config.json` on Windows. Claude Desktop launches from a minimal shell, so pass `JAVA_HOME` explicitly and use the full path to the `maestro` binary.
 
-### GitHub Copilot CLI
+</details>
 
-After [installing the Maestro CLI](../../maestro-cli/how-to-install-maestro-cli/README.md):
+<details>
 
-{% tabs %}
-{% tab title="Prompt" %}
-In a Copilot CLI session, run `/mcp add` and follow the interactive form:
+<summary>GitHub Copilot CLI</summary>
 
-* Name: `maestro`
-* Type: `local`
-* Command: `maestro`
-* Args: `mcp`
-{% endtab %}
+1. [Install the Maestro CLI](../../maestro-cli/how-to-install-maestro-cli/README.md).
+2. In a Copilot CLI session, run `/mcp add` and follow the interactive form with:
 
-{% tab title="Install Manually" %}
-Add to `~/.copilot/mcp-config.json`:
+    * Name: `maestro`
+    * Type: `local`
+    * Command: `maestro`
+    * Args: `mcp`
 
-```json
-{
-    "mcpServers": {
-        "maestro": {
-            "type": "local",
-            "command": "maestro",
-            "args": ["mcp"]
+    Or add to `~/.copilot/mcp-config.json` manually:
+
+    ```json
+    {
+        "mcpServers": {
+            "maestro": {
+                "type": "local",
+                "command": "maestro",
+                "args": ["mcp"]
+            }
         }
     }
-}
-```
-{% endtab %}
-{% endtabs %}
+    ```
 
 See the [Copilot CLI MCP docs](https://docs.github.com/en/copilot/how-tos/copilot-cli/customize-copilot/add-mcp-servers).
 
-### Cursor IDE
+</details>
 
-After [installing the Maestro CLI](../../maestro-cli/how-to-install-maestro-cli/README.md):
+<details>
 
-{% tabs %}
-{% tab title="Cursor 3 (config file)" %}
-Add Maestro to `.cursor/mcp.json` (project scope) or `~/.cursor/mcp.json` (global scope):
+<summary>Cursor IDE</summary>
 
-```json
-{
-    "mcpServers": {
-        "maestro": {
-            "command": "maestro",
-            "args": ["mcp"]
+1. [Install the Maestro CLI](../../maestro-cli/how-to-install-maestro-cli/README.md).
+2. Add Maestro to `.cursor/mcp.json` (project scope) or `~/.cursor/mcp.json` (global scope):
+
+    ```json
+    {
+        "mcpServers": {
+            "maestro": {
+                "command": "maestro",
+                "args": ["mcp"]
+            }
         }
     }
-}
-```
+    ```
 
-Open **Cursor Settings → Features → Model Context Protocol** to confirm the `maestro` server is toggled on.
-{% endtab %}
+3. Open **Cursor Settings → Features → Model Context Protocol** to confirm the `maestro` server is toggled on.
 
-{% tab title="Classic UI" %}
-On older Cursor versions, go to **Cursor Settings → MCP → Add new MCP Server**. Name it `maestro`, choose the `command` type, and enter `maestro mcp` as the command.
-{% endtab %}
-{% endtabs %}
+On older Cursor versions, the equivalent UI path is **Cursor Settings → MCP → Add new MCP Server**. Name it `maestro`, choose the `command` type, and enter `maestro mcp` as the command.
 
 See the [Cursor MCP docs](https://cursor.com/docs/context/mcp) for more.
 
-### Cursor CLI
+</details>
+
+<details>
+
+<summary>Cursor CLI</summary>
 
 The Cursor CLI shares its MCP config with the Cursor IDE. If Maestro is already set up in the IDE, there's nothing else to do.
 
-Otherwise, after [installing the Maestro CLI](../../maestro-cli/how-to-install-maestro-cli/README.md), add Maestro to `.cursor/mcp.json` in your project root:
+Otherwise:
 
-```json
-{
-    "mcpServers": {
-        "maestro": {
-            "command": "maestro",
-            "args": ["mcp"]
+1. [Install the Maestro CLI](../../maestro-cli/how-to-install-maestro-cli/README.md).
+2. Add Maestro to `.cursor/mcp.json` in your project root:
+
+    ```json
+    {
+        "mcpServers": {
+            "maestro": {
+                "command": "maestro",
+                "args": ["mcp"]
+            }
         }
     }
-}
-```
+    ```
 
 See the [Cursor CLI MCP docs](https://cursor.com/docs/cli/mcp).
 
-### Gemini CLI
+</details>
 
-After [installing the Maestro CLI](../../maestro-cli/how-to-install-maestro-cli/README.md):
+<details>
 
-{% tabs %}
-{% tab title="Prompt" %}
-Run:
+<summary>Gemini CLI</summary>
 
-```bash
-gemini mcp add maestro maestro mcp
-```
-{% endtab %}
+1. [Install the Maestro CLI](../../maestro-cli/how-to-install-maestro-cli/README.md).
+2. Run:
 
-{% tab title="Install Manually" %}
-Add to `~/.gemini/settings.json`:
+    ```bash
+    gemini mcp add maestro maestro mcp
+    ```
 
-```json
-{
-    "mcpServers": {
-        "maestro": {
-            "command": "maestro",
-            "args": ["mcp"]
+    Or add to `~/.gemini/settings.json` manually:
+
+    ```json
+    {
+        "mcpServers": {
+            "maestro": {
+                "command": "maestro",
+                "args": ["mcp"]
+            }
         }
     }
-}
-```
-{% endtab %}
-{% endtabs %}
+    ```
 
 See the [Gemini CLI MCP docs](https://geminicli.com/docs/tools/mcp-server/).
+
+</details>
 
 **For other IDEs, use the generic stdio config above and consult their documentation:**
 

--- a/introduction/get-started/maestro-mcp.md
+++ b/introduction/get-started/maestro-mcp.md
@@ -53,7 +53,7 @@ This assumes `maestro` is on your `PATH`. If it isn't, replace `"maestro"` with 
 2. Run:
 
     ```bash
-    claude mcp add maestro maestro mcp
+    claude mcp add maestro -- maestro mcp
     ```
 
 See the [Claude Code MCP docs](https://docs.claude.com/en/docs/claude-code/mcp) for scope options (`--scope user`, `--scope project`, etc.).
@@ -130,7 +130,7 @@ Otherwise:
     {
         "mcpServers": {
             "maestro": {
-                "type": "stdio",
+                "type": "local",
                 "command": "maestro",
                 "args": ["mcp"]
             }

--- a/introduction/get-started/maestro-mcp.md
+++ b/introduction/get-started/maestro-mcp.md
@@ -47,7 +47,7 @@ This assumes `maestro` is on your `PATH`. If it isn't, replace `"maestro"` with 
 
 <details>
 
-<summary>Claude Code CLI</summary>
+<summary><i class="fa-sparkles">:sparkles:</i> Claude Code CLI</summary>
 
 1. [Install the Maestro CLI](https://docs.maestro.dev/maestro-cli/how-to-install-maestro-cli).
 2. Run:
@@ -64,7 +64,7 @@ See the [Claude Code MCP docs](https://docs.claude.com/en/docs/claude-code/mcp) 
 
 <details>
 
-<summary>Codex</summary>
+<summary><i class="fa-atom">:atom:</i> Codex</summary>
 
 1. [Install the Maestro CLI](https://docs.maestro.dev/maestro-cli/how-to-install-maestro-cli).
 2. Run:
@@ -87,7 +87,7 @@ See the [Codex MCP docs](https://developers.openai.com/codex/mcp) and the [confi
 
 <details>
 
-<summary>Claude Desktop</summary>
+<summary><i class="fa-desktop">:desktop:</i> Claude Desktop</summary>
 
 1. [Install the Maestro CLI](https://docs.maestro.dev/maestro-cli/how-to-install-maestro-cli).
 2. In Claude Desktop, open **Settings → Developer → Edit Config** and merge the following into `claude_desktop_config.json`:
@@ -121,7 +121,7 @@ The **Connectors** UI in Claude Desktop only supports remote MCP servers that us
 
 <details>
 
-<summary>GitHub Copilot CLI</summary>
+<summary><i class="fa-github">:github:</i> GitHub Copilot CLI</summary>
 
 1. [Install the Maestro CLI](https://docs.maestro.dev/maestro-cli/how-to-install-maestro-cli).
 2. In a Copilot CLI session, run `/mcp add` and follow the interactive form with:
@@ -150,7 +150,7 @@ See the [Copilot CLI MCP docs](https://docs.github.com/en/copilot/how-tos/copilo
 
 <details>
 
-<summary>Cursor IDE</summary>
+<summary><i class="fa-cube">:cube:</i> Cursor IDE</summary>
 
 1. [Install the Maestro CLI](https://docs.maestro.dev/maestro-cli/how-to-install-maestro-cli).
 2. Install the MCP. The quickest option is the one-click button:
@@ -176,7 +176,7 @@ See the [Cursor MCP docs](https://cursor.com/docs/context/mcp) for more.
 
 <details>
 
-<summary>Cursor CLI</summary>
+<summary><i class="fa-terminal">:terminal:</i> Cursor CLI</summary>
 
 The Cursor CLI shares its MCP config with the Cursor IDE. If Maestro is already set up in the IDE, there's nothing else to do.
 
@@ -202,7 +202,7 @@ See the [Cursor CLI MCP docs](https://cursor.com/docs/cli/mcp).
 
 <details>
 
-<summary>Gemini CLI</summary>
+<summary><i class="fa-gem">:gem:</i> Gemini CLI</summary>
 
 1. [Install the Maestro CLI](https://docs.maestro.dev/maestro-cli/how-to-install-maestro-cli).
 2. Run:

--- a/introduction/get-started/maestro-mcp.md
+++ b/introduction/get-started/maestro-mcp.md
@@ -153,7 +153,11 @@ See the [Copilot CLI MCP docs](https://docs.github.com/en/copilot/how-tos/copilo
 <summary>Cursor IDE</summary>
 
 1. [Install the Maestro CLI](https://docs.maestro.dev/maestro-cli/how-to-install-maestro-cli).
-2. Open **Cursor Settings → Tools & MCPs → Add Custom MCP**. Cursor opens `~/.cursor/mcp.json` for editing. Merge the following into it (or into a project-scoped `.cursor/mcp.json` in your repo root):
+2. Install the MCP. The quickest option is the one-click deep link:
+
+    [**Add Maestro to Cursor**](cursor://anysphere.cursor-deeplink/mcp/install?name=maestro&config=eyJjb21tYW5kIjoibWFlc3RybyBtY3AifQ%3D%3D)
+
+    Or set it up manually: open **Cursor Settings → Tools & MCPs → Add Custom MCP**. Cursor opens `~/.cursor/mcp.json` for editing. Merge the following into it (or into a project-scoped `.cursor/mcp.json` in your repo root):
 
     ```json
     {

--- a/introduction/get-started/maestro-mcp.md
+++ b/introduction/get-started/maestro-mcp.md
@@ -1,80 +1,320 @@
 ---
 description: >-
-  Use Maestro's Model Context Protocol (MCP) to integrate AI assistants with
-  mobile testing.
+  Use Maestro's Model Context Protocol (MCP) server to let your coding agent
+  write, run, and debug mobile and web UI tests.
 ---
 
 # Maestro MCP Server
 
-Maestro implements the [Model Context Protocol (MCP)](https://modelcontextprotocol.io/docs/getting-started/intro), enabling direct integration with MCP-compliant client apps such as Claude, Cursor, and Windsurf.
+Maestro implements the [Model Context Protocol (MCP)](https://modelcontextprotocol.io/docs/getting-started/intro), enabling direct integration with MCP-compliant coding agents such as Claude Code, Claude Desktop, Cursor, GitHub Copilot, Codex, Gemini, Windsurf, and JetBrains AI Assistant.
 
 The Model Context Protocol is an open standard that provides a uniform interface for connecting Large Language Models to external data sources, tools, and services. MCP defines a client-server architecture where:
 
-* **MCP Servers** expose resources like data sources, APIs, and tools through a standardized interface
-* **MCP Clients**, such as AI apps, consume these resources via the protocol
-* **Transport Layer** handles communication using JSON Remote Procedure Call (RPC) 2.0 over stdio, HTTP with Server-Sent Events (SSE), or WebSocket connections
+* **MCP Servers** expose resources like data sources, APIs, and tools through a standardized interface.
+* **MCP Clients**, such as AI apps, consume these resources via the protocol.
+* **Transport Layer** handles communication using JSON-RPC 2.0 over stdio, HTTP with Server-Sent Events (SSE), or WebSocket connections.
 
-This architectural pattern decouples LLMs from specific integrations, allowing Maestro to function as an MCP server that exposes its capabilities through a protocol-defined interface rather than requiring custom SDK implementations for each client.
+The Maestro MCP server ships inside the Maestro CLI and exposes Maestro's authoring, device, and Cloud capabilities to your agent over stdio.
 
 ## Prerequisites
 
-To install and use the Maestro MCP server, you need the following:
+* The [Maestro CLI](../../maestro-cli/how-to-install-maestro-cli/README.md) installed and available on your `PATH`.
+* A coding agent that supports MCP (see the install paths below).
 
-* Maestro command-line tool installed
-* An IDE compatible with MCP servers
+## Install the Maestro MCP server on your coding agent
 
-## Install the Maestro MCP server
+Installing the Maestro MCP takes two steps:
 
-To install the Maestro MCP server, on your terminal, run `maestro mcp`
+1. [Install the Maestro CLI](../../maestro-cli/how-to-install-maestro-cli/README.md) (via the curl script or Homebrew).
+2. Register the Maestro MCP with your coding agent, using either the agent's one-line install command or a manual JSON/TOML config.
 
-The Maestro command-line tool preinstalls the MCP server, so this is enough to install.
-
-## Configure the MCP server on your IDE
-
-Most IDEs have a `json` configuration file to indicate to IDE how to run the MCP server. To do this, open your MCP configuration file. For example, if you're using Claude Desktop, it is `~/Library/Application Support/Claude/claude_desktop_config.json` on macOS or `%APPDATA%\Claude\claude_desktop_config.json` on Windows. For VSCode, edit the `.vscode/mcp.json` for your workspace.
-
-The `json` configuration file for Maestro MCP serve is:
+If your agent isn't listed below, the generic stdio config is:
 
 ```json
 {
     "mcpServers": {
         "maestro": {
             "command": "maestro",
-            "args": [
-                "mcp"
-            ]
+            "args": ["mcp"]
         }
     }
 }
 ```
 
 {% hint style="info" %}
-Assumes Maestro CLI is installed and available on your PATH. If it's not on your PATH, use the full path to the Maestro CLI executable instead of `maestro`.
+This assumes `maestro` is on your `PATH`. If it isn't, replace `"maestro"` with the full path to the Maestro CLI executable (e.g. `/opt/homebrew/bin/maestro`).
 {% endhint %}
 
-**For other IDEs and more information, consult their documentation:**
+<details>
 
-* [Codex](https://developers.openai.com/codex/mcp)
-* [Cursor](https://cursor.com/docs/context/mcp#installing-mcp-servers)
+<summary>Claude Code CLI</summary>
+
+1. [Install the Maestro CLI](../../maestro-cli/how-to-install-maestro-cli/README.md).
+2. Run:
+
+    ```bash
+    claude mcp add maestro maestro mcp
+    ```
+
+See the [Claude Code MCP docs](https://docs.claude.com/en/docs/claude-code/mcp) for scope options (`--scope user`, `--scope project`, etc.).
+
+</details>
+
+<details>
+
+<summary>Claude Desktop</summary>
+
+1. [Install the Maestro CLI](../../maestro-cli/how-to-install-maestro-cli/README.md).
+2. Add Maestro to Claude Desktop's config.
+
+{% tabs %}
+{% tab title="Prompt" %}
+In a Claude Desktop Code tab, prompt:
+
+```
+update claude_desktop_config.json to add the maestro mcp server:
+"maestro": { "command": "<full path to maestro>", "args": ["mcp"], "env": { <include JAVA_HOME> } }
+```
+{% endtab %}
+
+{% tab title="Manual" %}
+Open **Settings → Developer → Edit Config** and merge:
+
+```json
+{
+    "mcpServers": {
+        "maestro": {
+            "command": "<full path to maestro binary>",
+            "args": ["mcp"],
+            "env": {
+                "JAVA_HOME": "<full JAVA_HOME directory>"
+            }
+        }
+    }
+}
+```
+
+The config file lives at `~/Library/Application Support/Claude/claude_desktop_config.json` on macOS or `%APPDATA%\Claude\claude_desktop_config.json` on Windows. Claude Desktop launches from a minimal shell, so pass `JAVA_HOME` explicitly and use the full path to the `maestro` binary.
+{% endtab %}
+{% endtabs %}
+
+</details>
+
+<details>
+
+<summary>Cursor IDE</summary>
+
+1. [Install the Maestro CLI](../../maestro-cli/how-to-install-maestro-cli/README.md).
+2. Open **Cursor Settings → MCP → Add new MCP Server**. Name it `maestro`, choose the `command` type, and enter `maestro mcp` as the command.
+
+Alternatively, add to `.cursor/mcp.json` in your project root:
+
+```json
+{
+    "mcpServers": {
+        "maestro": {
+            "command": "maestro",
+            "args": ["mcp"]
+        }
+    }
+}
+```
+
+See the [Cursor MCP docs](https://cursor.com/docs/context/mcp#installing-mcp-servers) for more.
+
+</details>
+
+<details>
+
+<summary>Cursor CLI</summary>
+
+The Cursor CLI shares its MCP config with the Cursor IDE. If Maestro is already set up in the IDE, there's nothing else to do.
+
+Otherwise:
+
+1. [Install the Maestro CLI](../../maestro-cli/how-to-install-maestro-cli/README.md).
+2. Add Maestro to `.cursor/mcp.json`.
+
+{% tabs %}
+{% tab title="Prompt" %}
+In a cursor-agent session, prompt:
+
+```
+update .cursor/mcp.json to add the maestro mcp server:
+"maestro": { "command": "maestro", "args": ["mcp"] }
+```
+{% endtab %}
+
+{% tab title="Manual" %}
+Add to `.cursor/mcp.json` in your project root:
+
+```json
+{
+    "mcpServers": {
+        "maestro": {
+            "command": "maestro",
+            "args": ["mcp"]
+        }
+    }
+}
+```
+
+See the [Cursor CLI MCP docs](https://cursor.com/docs/cli/mcp).
+{% endtab %}
+{% endtabs %}
+
+</details>
+
+<details>
+
+<summary>GitHub Copilot CLI</summary>
+
+1. [Install the Maestro CLI](../../maestro-cli/how-to-install-maestro-cli/README.md).
+2. Add Maestro to Copilot CLI.
+
+{% tabs %}
+{% tab title="Prompt" %}
+In a Copilot CLI session, run `/mcp add` and follow the interactive form:
+
+* Name: `maestro`
+* Type: `stdio`
+* Command: `maestro`
+* Args: `mcp`
+
+See the [Copilot CLI MCP docs](https://docs.github.com/en/copilot/how-tos/copilot-cli/customize-copilot/add-mcp-servers).
+{% endtab %}
+
+{% tab title="Manual" %}
+Add to `~/.copilot/mcp-config.json`:
+
+```json
+{
+    "mcpServers": {
+        "maestro": {
+            "type": "stdio",
+            "command": "maestro",
+            "args": ["mcp"]
+        }
+    }
+}
+```
+{% endtab %}
+{% endtabs %}
+
+</details>
+
+<details>
+
+<summary>Codex</summary>
+
+1. [Install the Maestro CLI](../../maestro-cli/how-to-install-maestro-cli/README.md).
+2. Add Maestro to Codex.
+
+{% tabs %}
+{% tab title="Prompt" %}
+Run:
+
+```bash
+codex mcp add maestro -- maestro mcp
+```
+
+See the [Codex MCP docs](https://developers.openai.com/codex/mcp).
+{% endtab %}
+
+{% tab title="Manual" %}
+Add to `~/.codex/config.toml`:
+
+```toml
+[mcp_servers.maestro]
+command = "maestro"
+args = ["mcp"]
+```
+
+See the [Codex config reference](https://developers.openai.com/codex/config-reference).
+{% endtab %}
+{% endtabs %}
+
+</details>
+
+<details>
+
+<summary>Gemini CLI</summary>
+
+1. [Install the Maestro CLI](../../maestro-cli/how-to-install-maestro-cli/README.md).
+2. Add Maestro to Gemini CLI.
+
+{% tabs %}
+{% tab title="Prompt" %}
+Run:
+
+```bash
+gemini mcp add maestro maestro mcp
+```
+
+See the [Gemini CLI MCP docs](https://geminicli.com/docs/tools/mcp-server/).
+{% endtab %}
+
+{% tab title="Manual" %}
+Add to `~/.gemini/settings.json`:
+
+```json
+{
+    "mcpServers": {
+        "maestro": {
+            "command": "maestro",
+            "args": ["mcp"]
+        }
+    }
+}
+```
+{% endtab %}
+{% endtabs %}
+
+</details>
+
+**For other IDEs, use the generic stdio config above and consult their documentation:**
+
+* [VS Code](https://code.visualstudio.com/docs/copilot/chat/mcp-servers#_add-an-mcp-server)
 * [JetBrains IDEs](https://www.jetbrains.com/help/ai-assistant/configure-an-mcp-server.html)
-* [VSCode](https://code.visualstudio.com/docs/copilot/chat/mcp-servers#_add-an-mcp-server)
 * [Windsurf](https://docs.windsurf.com/windsurf/cascade/mcp)
 
-## MCP commands
+## Update the Maestro MCP server
 
-| Command                  | Description                                                            |
-| ------------------------ | ---------------------------------------------------------------------- |
-| `back`                   | Press the back button.                                                 |
-| `cheat_sheet`            | Get the Maestro cheat sheet with common commands and syntax examples.  |
-| `check_flow_syntax`      | Validates the syntax of a flow.                                        |
-| `input_text`             | Input text to the current focused text field.                          |
-| `inspect_view_hierarchy` | Get the nested views hierarchy of the current screen in CSV format.    |
-| `launch_app`             | Launch an app on the connected device.                                 |
-| `list_devices`           | List all devices.                                                      |
-| `query_docs`             | Query the Maestro documentation for specific information.              |
-| `run_flow`               | Run a flow.                                                            |
-| `run_flow_files`         | Run one or more full Maestro flows.                                    |
-| `start_device`           | Start a device like a simulator or emulator and returns the device ID. |
-| `stop_app`               | Stop an app on the connected device.                                   |
-| `take_screenshot`        | Take a screenshot of the current device screen.                        |
-| `tap_on`                 | Tap on a UI element using the selector description.                    |
+The Maestro MCP is bundled inside the Maestro CLI, so upgrading the CLI upgrades the MCP server. After upgrading, your agent needs to reload the MCP connection to pick up the new binary.
+
+1. [Update the Maestro CLI](../../maestro-cli/how-to-install-maestro-cli/update-the-maestro-cli.md).
+2. Reload the Maestro MCP in your agent:
+
+| Agent                | How to reload                                                                  |
+| -------------------- | ------------------------------------------------------------------------------ |
+| Claude Code CLI      | Run `/mcp`, select **maestro**, then **Reconnect**.                            |
+| Claude Desktop       | Restart Claude Desktop.                                                        |
+| Cursor IDE           | **Cursor Settings → MCP → Restart** the Maestro server, or restart Cursor.     |
+| Cursor CLI           | Restart `cursor-agent`. No in-session reload command exists.                   |
+| GitHub Copilot CLI   | Restart the Copilot CLI.                                                       |
+| Codex                | Restart the Codex CLI.                                                         |
+| Gemini CLI           | Restart the Gemini CLI.                                                        |
+
+## MCP tools
+
+Maestro's MCP server exposes the following tools. The server also ships instructions that guide the agent through the local (`list_devices → inspect_screen → run`) and Cloud (`list_cloud_devices → run_on_cloud → get_cloud_run_status`) workflows.
+
+### Local
+
+| Tool              | Description                                                                                                                                                                                              |
+| ----------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `list_devices`    | List all available local devices (Android emulators, iOS simulators, and Chromium for web) that can be targeted for automation.                                                                           |
+| `inspect_screen`  | Get the current screen's view hierarchy as compact JSON. Call this before targeting elements, and re-call after any UI change.                                                                            |
+| `take_screenshot` | Take a screenshot of the current device screen. Useful when a visual helps disambiguate elements.                                                                                                         |
+| `run`             | Execute Maestro flows. Accepts exactly one of `{ yaml }` (inline YAML, preferred for exploration), `{ files }` (specific `.yaml` files), or `{ dir, include_tags, exclude_tags }`. Syntax is validated as part of the call. Replaces the old `run_flow` + `run_flow_files` pair and the imperative single-action tools. |
+| `cheat_sheet`     | Return the Maestro cheat sheet covering common commands, flow syntax, and best practices. The agent should call this before authoring unfamiliar commands.                                                |
+
+### Cloud
+
+| Tool                    | Description                                                                                                                                                                        |
+| ----------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `list_cloud_devices`    | List valid `{ device_model, device_os }` pairs available on Maestro Cloud. Call before `run_on_cloud` — OS versions must be passed verbatim (e.g. `iOS-17-5`, `android-34`).         |
+| `run_on_cloud`          | Submit a flow (or folder of flows) to Maestro Cloud. Returns `upload_id`, `project_id`, and a dashboard URL immediately.                                                            |
+| `get_cloud_run_status`  | Poll the status and per-flow results of a Cloud run. Poll every 60s until the status is terminal (`SUCCESS`, `ERROR`, `CANCELED`, `WARNING`).                                       |
+
+Cloud tools require Maestro Cloud authentication: run `maestro login` (recommended) or set `MAESTRO_CLOUD_API_KEY` for non-interactive environments.

--- a/introduction/get-started/maestro-mcp.md
+++ b/introduction/get-started/maestro-mcp.md
@@ -218,7 +218,7 @@ See the [Cursor CLI MCP docs](https://cursor.com/docs/cli/mcp).
     }
     ```
 
-See the [Gemini CLI MCP docs](https://geminicli.com/docs/tools/mcp-server/).
+See the [Gemini CLI MCP docs](https://geminicli.com/docs/tools/mcp-server/) for scope options (`-s user` writes to `~/.gemini/settings.json`, `-s project` to `.gemini/settings.json`; default is `project`).
 
 </details>
 

--- a/introduction/get-started/maestro-mcp.md
+++ b/introduction/get-started/maestro-mcp.md
@@ -147,7 +147,7 @@ See the [Copilot CLI MCP docs](https://docs.github.com/en/copilot/how-tos/copilo
 <summary>Cursor IDE</summary>
 
 1. [Install the Maestro CLI](../../maestro-cli/how-to-install-maestro-cli/README.md).
-2. Add Maestro to `.cursor/mcp.json` (project scope) or `~/.cursor/mcp.json` (global scope):
+2. Open **Cursor Settings → Tools & MCPs → Add Custom MCP**. Cursor opens `~/.cursor/mcp.json` for editing. Merge the following into it (or into a project-scoped `.cursor/mcp.json` in your repo root):
 
     ```json
     {
@@ -159,8 +159,6 @@ See the [Copilot CLI MCP docs](https://docs.github.com/en/copilot/how-tos/copilo
         }
     }
     ```
-
-3. Open **Cursor Settings → Features → Model Context Protocol** to confirm the `maestro` server is toggled on.
 
 On older Cursor versions, the equivalent UI path is **Cursor Settings → MCP → Add new MCP Server**. Name it `maestro`, choose the `command` type, and enter `maestro mcp` as the command.
 


### PR DESCRIPTION
Updates the Maestro MCP docs with the new install + update flows for each supported coding agent. Tool-table changes are intentionally out of scope here and will land in a follow-up PR.

## Changes

**Install section** — Replaces the single generic config block with per-agent collapsed `<details>` blocks for Claude Code CLI, Codex, Claude Desktop, GitHub Copilot CLI, Cursor IDE, Cursor CLI, and Gemini CLI. Each block contains the one-line install command where available and the manual JSON/TOML config as a fallback.

* **Claude Code CLI**: `claude mcp add maestro -- maestro mcp` (with the modern `--` separator).
* **Codex**: `codex mcp add maestro -- maestro mcp` or `~/.codex/config.toml`.
* **Claude Desktop**: `Settings → Developer → Edit Config` with `JAVA_HOME` and full-path-to-binary notes. Includes an info hint that the **Connectors** UI is for remote/OAuth MCPs only, so local stdio servers like Maestro must be added via `claude_desktop_config.json`.
* **GitHub Copilot CLI**: interactive `/mcp add` (Name / Type `local` / Command) or `~/.copilot/mcp-config.json`.
* **Cursor IDE**: official one-click **Install MCP Server** button (`https://cursor.com/en-US/install-mcp`) plus the manual path **Cursor Settings → Tools & MCPs → Add Custom MCP**, which opens `~/.cursor/mcp.json` (global) or project-scoped `.cursor/mcp.json`.
* **Cursor CLI**: shares MCP config with the Cursor IDE; manual `.cursor/mcp.json` fallback.
* **Gemini CLI**: `gemini mcp add maestro maestro mcp` or `~/.gemini/settings.json`.

VS Code, JetBrains, and Windsurf are kept as a trailing doc-links list, since there's no agent-specific one-liner needed beyond the generic stdio config.

Scope notes for Claude Code CLI and Gemini CLI are shown inside `{% hint style="info" %}` info cards.

**Update section** — New section covering the CLI-upgrade-then-reload flow, with a per-agent reload table.

Cross-repo links to the Maestro CLI install / update pages use absolute `https://docs.maestro.dev/...` URLs so GitBook resolves them as internal navigation on the published site.

## Out of scope (follow-up PR)
- Updating the MCP tools table to the current 8-tool set (split local vs. Cloud, etc.).

## Test plan
- [ ] Verify GitBook preview renders all install `<details>` blocks and info hints correctly.
- [ ] Verify every install command matches the current upstream agent CLI syntax.
- [ ] Confirm the reload table renders as expected.
- [ ] Sanity-check in-page links to CLI install / update docs resolve.
