### PR TITLE
Update MCP tools list for Maestro CLI 2.5.0

### DIFF
--- a/introduction/get-started/maestro-mcp.md
+++ b/introduction/get-started/maestro-mcp.md
@@ -253,21 +253,19 @@ The Maestro MCP is bundled inside the Maestro CLI, so upgrading the CLI upgrades
 | Cursor CLI         | Restart `cursor-agent`. No in-session reload command exists.                                    |
 | Gemini CLI         | Restart the Gemini CLI.                                                                         |
 
-## MCP commands
+## MCP tools
 
-| Command                  | Description                                                            |
-| ------------------------ | ---------------------------------------------------------------------- |
-| `back`                   | Press the back button.                                                 |
-| `cheat_sheet`            | Get the Maestro cheat sheet with common commands and syntax examples.  |
-| `check_flow_syntax`      | Validates the syntax of a flow.                                        |
-| `input_text`             | Input text to the current focused text field.                          |
-| `inspect_view_hierarchy` | Get the nested views hierarchy of the current screen in CSV format.    |
-| `launch_app`             | Launch an app on the connected device.                                 |
-| `list_devices`           | List all devices.                                                      |
-| `query_docs`             | Query the Maestro documentation for specific information.              |
-| `run_flow`               | Run a flow.                                                            |
-| `run_flow_files`         | Run one or more full Maestro flows.                                    |
-| `start_device`           | Start a device like a simulator or emulator and returns the device ID. |
-| `stop_app`               | Stop an app on the connected device.                                   |
-| `take_screenshot`        | Take a screenshot of the current device screen.                        |
-| `tap_on`                 | Tap on a UI element using the selector description.                    |
+| Tool                   | Description                                                                                                                                                                                              |
+| ---------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `list_devices`         | List all available local devices (Android emulators, iOS simulators, and Chromium for web) that can be targeted for automation.                                                                           |
+| `inspect_screen`       | Get the current screen's view hierarchy as compact JSON. Call this before targeting elements, and re-call after any UI change.                                                                            |
+| `take_screenshot`      | Take a screenshot of the current device screen. Useful when a visual helps disambiguate elements.                                                                                                         |
+| `run`                  | Execute Maestro flows. Accepts exactly one of `{ yaml }` (inline YAML, preferred for exploration), `{ files }` (specific `.yaml` files), or `{ dir, include_tags, exclude_tags }`. Syntax is validated as part of the call.                                                                                            |
+| `cheat_sheet`          | Return the Maestro cheat sheet covering common commands, flow syntax, and best practices. The agent should call this before authoring unfamiliar commands.                                                |
+| `list_cloud_devices`   | List valid `{ device_model, device_os }` pairs available on Maestro Cloud. Call before `run_on_cloud`. OS versions must be passed verbatim (e.g. `iOS-17-5`, `android-34`).                                |
+| `run_on_cloud`         | Submit a flow (or folder of flows) to Maestro Cloud. Returns `upload_id`, `project_id`, and a dashboard URL immediately.                                                                                  |
+| `get_cloud_run_status` | Poll the status and per-flow results of a Cloud run. Poll every 60s until the status is terminal (`SUCCESS`, `ERROR`, `CANCELED`, `WARNING`).                                                             |
+
+{% hint style="info" %}
+The `list_cloud_devices`, `run_on_cloud`, and `get_cloud_run_status` tools require Maestro Cloud authentication. Run `maestro login` (recommended) or set `MAESTRO_CLOUD_API_KEY` for non-interactive environments.
+{% endhint %}


### PR DESCRIPTION
Updates the Maestro MCP tools section to reflect the trimmed-down tool set shipped in Maestro CLI 2.5.0.

## Changes

The previous 15-tool table is replaced with the current 8-tool set, split into local + Cloud workflows in a single unified table:

**Local**
- `list_devices`, `inspect_screen`, `take_screenshot`, `run`, `cheat_sheet`

**Cloud** (require Maestro Cloud auth via `maestro login` or `MAESTRO_CLOUD_API_KEY`)
- `list_cloud_devices`, `run_on_cloud`, `get_cloud_run_status`

Dropped from the previous list (covered by `run` with inline YAML or by server instructions):
- `tap_on`, `input_text`, `back`, `launch_app`, `stop_app` — replaced by `run` with one-line YAML fragments.
- `run_flow` + `run_flow_files` — consolidated into `run`.
- `check_flow_syntax` — `run` validates syntax inline.
- `start_device` — rare setup step; users typically pre-boot the device.
- `query_docs` — replaced by a docs link surfaced through server instructions.
- `inspect_view_hierarchy` — replaced by `inspect_screen` with compact JSON output.

The Cloud-auth requirement is called out as an info hint below the table.

Section heading renamed from **MCP commands** to **MCP tools** to match MCP terminology.

## Test plan
- [ ] Verify GitBook preview renders the unified tools table and Cloud auth hint correctly.
- [ ] Spot-check tool descriptions against the upstream Kotlin tool implementations on `mobile-dev-inc/Maestro` main.
