### PR TITLE
Document list-devices, list-cloud-devices, and updated device flags

### DIFF
--- a/cloud/ci-cd-integration/github-actions/README.md
+++ b/cloud/ci-cd-integration/github-actions/README.md
@@ -115,8 +115,8 @@ Below are all available inputs for the `mobile-dev-inc/action-maestro-cloud` act
 | Input               | Description                                                                                       | Example        |
 | ------------------- | ------------------------------------------------------------------------------------------------- | -------------- |
 | `android-api-level` | Android API level. (Deprecated - use `device-os` instead.)                                        | `30`           |
-| `device-model`      | Device model to run against. iOS: `iPhone-11`, `iPhone-16`, etc. Android: `pixel_6`, `pixel_7`, etc. Run `maestro list-cloud-devices` to see all supported models. | `iPhone-16`    |
-| `device-os`         | OS version to run against. iOS: `iOS-17-5`, `iOS-18-2`, etc. Android: `android-33`, `android-34`, etc. Run `maestro list-cloud-devices` to see all supported versions. | `iOS-18-2`     |
+| `device-model`      | Device model to run against. Run `maestro list-cloud-devices` to see all supported models.                                                                         | `iPhone-16` , `pixel_6` |
+| `device-os`         | OS version to run against. Run `maestro list-cloud-devices` to see all supported versions.                                                                             | `iOS-18-2`, `android-34` |
 | `device-locale`     | Device locale (ISO-639-1 + ISO-3166-1).                                                           | `de_DE`        |
 | `mapping-file`      | Path to ProGuard map (Android) or dSYM (iOS).                                                     | `./MyApp.dSYM` |
 

--- a/cloud/ci-cd-integration/github-actions/README.md
+++ b/cloud/ci-cd-integration/github-actions/README.md
@@ -112,13 +112,13 @@ Below are all available inputs for the `mobile-dev-inc/action-maestro-cloud` act
 
 #### Device configuration
 
-| Input               | Description                                   | Example        |
-| ------------------- | --------------------------------------------- | -------------- |
-| `android-api-level` | Android API level to use.                     | `30`           |
-| `device-model`      | Specific iOS device model.                    | `iPhone-16`    |
-| `device-os`         | Specific iOS OS version.                      | `iOS-18-2`     |
-| `device-locale`     | Device locale (ISO-639-1 + ISO-3166-1).       | `de_DE`        |
-| `mapping-file`      | Path to ProGuard map (Android) or dSYM (iOS). | `./MyApp.dSYM` |
+| Input               | Description                                                                                       | Example        |
+| ------------------- | ------------------------------------------------------------------------------------------------- | -------------- |
+| `android-api-level` | (Deprecated) Android API level. Use `device-os` instead.                                          | `30`           |
+| `device-model`      | Device model to run against. iOS: `iPhone-11`, `iPhone-16`, etc. Android: `pixel_6`, `pixel_7`, etc. Run `maestro list-cloud-devices` to see all supported models. | `iPhone-16`    |
+| `device-os`         | OS version to run against. iOS: `iOS-17-5`, `iOS-18-2`, etc. Android: `android-33`, `android-34`, etc. Run `maestro list-cloud-devices` to see all supported versions. | `iOS-18-2`     |
+| `device-locale`     | Device locale (ISO-639-1 + ISO-3166-1).                                                           | `de_DE`        |
+| `mapping-file`      | Path to ProGuard map (Android) or dSYM (iOS).                                                     | `./MyApp.dSYM` |
 
 {% hint style="info" %}
 Access the [configure-the-os.md](../../environment-configuration/configure-the-os.md "mention") page for more information.

--- a/cloud/ci-cd-integration/github-actions/README.md
+++ b/cloud/ci-cd-integration/github-actions/README.md
@@ -114,7 +114,7 @@ Below are all available inputs for the `mobile-dev-inc/action-maestro-cloud` act
 
 | Input               | Description                                                                                       | Example        |
 | ------------------- | ------------------------------------------------------------------------------------------------- | -------------- |
-| `android-api-level` | (Deprecated) Android API level. Use `device-os` instead.                                          | `30`           |
+| `android-api-level` | Android API level. (Deprecated - use `device-os` instead.)                                        | `30`           |
 | `device-model`      | Device model to run against. iOS: `iPhone-11`, `iPhone-16`, etc. Android: `pixel_6`, `pixel_7`, etc. Run `maestro list-cloud-devices` to see all supported models. | `iPhone-16`    |
 | `device-os`         | OS version to run against. iOS: `iOS-17-5`, `iOS-18-2`, etc. Android: `android-33`, `android-34`, etc. Run `maestro list-cloud-devices` to see all supported versions. | `iOS-18-2`     |
 | `device-locale`     | Device locale (ISO-639-1 + ISO-3166-1).                                                           | `de_DE`        |

--- a/cloud/ci-cd-integration/github-actions/platform-guides.md
+++ b/cloud/ci-cd-integration/github-actions/platform-guides.md
@@ -52,15 +52,20 @@ If your app uses ProGuard/R8, you should upload the mapping file to deobfuscate 
     mapping-file: app/build/outputs/mapping/release/mapping.txt
 ```
 
-#### Specifying Android API level
+#### Specifying the Android OS version and device
 
-The default API level on Maestro Cloud is 33 (Android 13). You can override this using `android-api-level`.
+The default API level on Maestro Cloud is 33 (Android 13). You can override the OS version and the device model using `device-os` and `device-model`:
 
 ```yaml
 with:
   # ... other inputs
-  android-api-level: 29
+  device-model: pixel_6
+  device-os: android-29
 ```
+
+{% hint style="info" %}
+The `android-api-level` input is deprecated in favor of `device-os`. Run `maestro list-cloud-devices` to see all supported Android device models and OS versions.
+{% endhint %}
 
 #### Complete example for Android
 
@@ -149,6 +154,10 @@ with:
   device-model: iPhone-16
   device-os: iOS-18-2
 ```
+
+{% hint style="info" %}
+The `ios-version` input is deprecated in favor of `device-os`. Run `maestro list-cloud-devices` to see all supported iOS device models and OS versions.
+{% endhint %}
 
 #### Complete example for iOS
 

--- a/cloud/environment-configuration/configure-the-os.md
+++ b/cloud/environment-configuration/configure-the-os.md
@@ -1,7 +1,8 @@
 ---
 description: >-
-  Set Android API levels or iOS runtime versions and device models for Maestro
-  Cloud tests. Supports Android 10-14 and iOS 16-24.
+  Set OS versions and device models for Maestro Cloud tests using the
+  `--device-os` and `--device-model` flags. Supports Android 10-14 and iOS
+  16-26.
 ---
 
 # Configure the OS
@@ -22,10 +23,10 @@ maestro list-cloud-devices
 
 ### Android
 
-You can specify the Android OS version (API level) using the `--device-os` flag when using Maestro Cloud.
+For Android, you can configure both the OS version and the device model. Use the `--device-os` and `--device-model` flags to select a specific combination:
 
 ```bash
-maestro cloud --device-os "<DEVICE_OS>" --app-file "<APP_FILE>" --flows "<FLOWS>"
+maestro cloud --device-os "<DEVICE_OS>" --device-model "<DEVICE_MODEL>" --app-file "<APP_FILE>" --flows "<FLOWS>"
 ```
 
 The following table lists the supported Android versions:
@@ -37,6 +38,14 @@ The following table lists the supported Android versions:
 | Android 12               | android-31            |
 | Android 11               | android-30            |
 | Android 10               | android-29            |
+
+For example, to run your flows on Android 14 using a Pixel 6, use the following command:
+
+```bash
+maestro cloud --device-os "android-34" --device-model "pixel_6" --app-file myapp.apk --flows myflows/
+```
+
+Run `maestro list-cloud-devices` to see the full list of supported Android device models.
 
 {% hint style="info" %}
 #### Reproducing Cloud runs locally
@@ -70,6 +79,8 @@ For example, to run your flows on iOS 26.2 using an iPhone 17 Pro, use the follo
 ```bash
 maestro cloud --device-os "iOS-26-2" --device-model "iPhone-17-Pro" --app-file myapp.app --flows myflows/
 ```
+
+Run `maestro list-cloud-devices` to see the full list of supported iOS device models and OS versions.
 
 {% hint style="info" %}
 #### Deprecated: `--ios-version`  & `--android-api-level`

--- a/cloud/environment-configuration/configure-the-os.md
+++ b/cloud/environment-configuration/configure-the-os.md
@@ -1,8 +1,7 @@
 ---
 description: >-
   Set OS versions and device models for Maestro Cloud tests using the
-  `--device-os` and `--device-model` flags. Supports Android 10-14 and iOS
-  16-26.
+  `--device-os` and `--device-model` flags.
 ---
 
 # Configure the OS
@@ -23,29 +22,19 @@ maestro list-cloud-devices
 
 ### Android
 
-For Android, you can configure both the OS version and the device model. Use the `--device-os` and `--device-model` flags to select a specific combination:
+You can specify the Android OS version using the `--device-os` flag when using Maestro Cloud:
 
 ```bash
-maestro cloud --device-os "<DEVICE_OS>" --device-model "<DEVICE_MODEL>" --app-file "<APP_FILE>" --flows "<FLOWS>"
+maestro cloud --device-os "<DEVICE_OS>" --app-file "<APP_FILE>" --flows "<FLOWS>"
 ```
 
-The following table lists the supported Android versions:
-
-| Android Version          | Device OS / API Level |
-| ------------------------ | --------------------- |
-| Android 14               | android-34            |
-| **Android 13 (Default)** | **android-33**        |
-| Android 12               | android-31            |
-| Android 11               | android-30            |
-| Android 10               | android-29            |
-
-For example, to run your flows on Android 14 using a Pixel 6, use the following command:
+For example, to run your flows on Android 14:
 
 ```bash
-maestro cloud --device-os "android-34" --device-model "pixel_6" --app-file myapp.apk --flows myflows/
+maestro cloud --device-os "android-34" --app-file myapp.apk --flows myflows/
 ```
 
-Run `maestro list-cloud-devices` to see the full list of supported Android device models.
+Run `maestro list-cloud-devices` to see the full list of supported Android OS versions.
 
 {% hint style="info" %}
 #### Reproducing Cloud runs locally
@@ -62,17 +51,6 @@ Maestro recommends specifying both the minor OS version and the device model. Us
 ```bash
 maestro cloud --device-os "<DEVICE_OS>" --device-model "<DEVICE_MODEL>" --app-file "<APP_FILE>" --flows "<FLOWS>"
 ```
-
-The following table lists an example of the supported device models and their available iOS versions:
-
-| Device Model             | Supported iOS Versions                 |
-| ------------------------ | -------------------------------------- |
-| **iPhone-11**            | iOS-16-4, iOS-17-5, iOS-18-2, iOS-26-2 |
-| **iPhone-13-mini**       | iOS-18-2, iOS-26-2                     |
-| **iPhone-16**            | iOS-18-2, iOS-26-2                     |
-| **iPhone-17-Pro**        | iOS-26-2                               |
-| **iPhone-17-Pro-Max**    | iOS-26-2                               |
-| **iPad-10th-generation** | iOS-16-4, iOS-17-5, iOS-18-2, iOS-26-2 |
 
 For example, to run your flows on iOS 26.2 using an iPhone 17 Pro, use the following command:
 

--- a/flows/flow-control-and-logic/specify-and-start-devices.md
+++ b/flows/flow-control-and-logic/specify-and-start-devices.md
@@ -18,16 +18,32 @@ To view all available options and configurations available, run:
 maestro start-device
 ```
 
-Maestro will list the devices, platforms, and OS versions available in the cloud, similar to the following example:
+Maestro will list the devices, platforms, and OS versions available, similar to the following example:
 
 ```
 Supported device types: iPhone11 (iOS), Pixel 6 (Android)
-      --os-version=<osVersion>
+      --device-model=<deviceModel>
+                       Device model to run against
+                       iOS: iPhone-11, iPhone-11-Pro, etc. Run command: maestro list-devices
+                       Android: pixel_6, pixel_7, etc. Run command: maestro list-devices
+      --device-os=<deviceOs>
                        OS version to use:
-                       iOS: 16, 17, 18
-                       Android: 28, 29, 30, 31, 33
+                       iOS: iOS-16-2, iOS-17-5, iOS-18-2, etc.
+                       Android: android-33, android-34, etc.
       --platform=<platform>
-                       Platforms: android, ios
+                       Platforms: android, ios, web
+```
+
+To list all supported local device models and OS versions, run:
+
+```bash
+maestro list-devices
+```
+
+To list the device models and OS versions available on Maestro Cloud, run:
+
+```bash
+maestro list-cloud-devices
 ```
 
 {% tabs %}

--- a/flows/flow-control-and-logic/specify-and-start-devices.md
+++ b/flows/flow-control-and-logic/specify-and-start-devices.md
@@ -28,8 +28,8 @@ Supported device types: iPhone11 (iOS), Pixel 6 (Android)
                        Android: pixel_6, pixel_7, etc. Run command: maestro list-devices
       --device-os=<deviceOs>
                        OS version to use:
-                       iOS: iOS-16-2, iOS-17-5, iOS-18-2, etc.
-                       Android: android-33, android-34, etc.
+                         iOS: iOS-18-2, iOS-26-2 etc.
+                         Android: android-33, android-34, etc.
       --platform=<platform>
                        Platforms: android, ios, web
 ```

--- a/maestro-cli/maestro-cli-commands-and-options.md
+++ b/maestro-cli/maestro-cli-commands-and-options.md
@@ -153,7 +153,7 @@ Launch an emulator or simulator.
 | `--device-os=<os>`         | OS version to use. iOS: `iOS-18-2`, `iOS-26-2` etc. Android: `android-33`, `android-34`, etc. Run `maestro list-devices` to see all supported versions. |
 | `--force-create`           | Overrides the existing device if it already exists.                                     |
 | `-h`, `--help`             | Display the help message.                                                               |
-| `--os-version=<version>`   | (Deprecated) OS version. Use `--device-os` instead.                                     |
+| `--os-version=<version>`   | OS version. (Deprecated - use `device-os` instead.)                                     |
 | `--platform=<platform>`    | Platforms: `android`, `ios`, or `web`                                                   |
 
 #### `list-devices`

--- a/maestro-cli/maestro-cli-commands-and-options.md
+++ b/maestro-cli/maestro-cli-commands-and-options.md
@@ -149,8 +149,8 @@ Launch an emulator or simulator.
 | Option                     | Description                                                                             |
 | -------------------------- | --------------------------------------------------------------------------------------- |
 | `--device-locale=<locale>` | Combination of lowercase ISO-639-1 code and uppercase ISO-3166-1 code (e.g., "de\_DE"). |
-| `--device-model=<model>`   | Device model to run against. iOS: `iPhone-11`, `iPhone-11-Pro`, etc. Android: `pixel_6`, `pixel_7`, etc. Run `maestro list-devices` to see all supported models. |
-| `--device-os=<os>`         | OS version to use. iOS: `iOS-16-2`, `iOS-17-5`, `iOS-18-2`, etc. Android: `android-33`, `android-34`, etc. Run `maestro list-devices` to see all supported versions. |
+| `--device-model=<model>`   | Device model to run against. iOS: `iPhone-11`, `iPhone-17-Pro`, etc. Android: `pixel_6`, `pixel_7`, etc. Run `maestro list-devices` to see all supported models. |
+| `--device-os=<os>`         | OS version to use. iOS: `iOS-18-2`, `iOS-26-2` etc. Android: `android-33`, `android-34`, etc. Run `maestro list-devices` to see all supported versions. |
 | `--force-create`           | Overrides the existing device if it already exists.                                     |
 | `-h`, `--help`             | Display the help message.                                                               |
 | `--os-version=<version>`   | (Deprecated) OS version. Use `--device-os` instead.                                     |

--- a/maestro-cli/maestro-cli-commands-and-options.md
+++ b/maestro-cli/maestro-cli-commands-and-options.md
@@ -44,14 +44,16 @@ You can pass these subcommands with the Maestro CLI:
 | `bugreport`        | Send a bug report.                                                                   |
 | `chat`             | Use Maestro GPT to help you with the apps and tests.                                 |
 | `cloud`            | Upload your Flows to Maestro Cloud.                                                  |
-| `download-samples` | Download sample Flows and sample apps for running with the Maestro CLI.              |
-| `driver-setup`     | Setup Maestro drivers for your device.                                               |
-| `login`            | Login into Maestro Cloud.                                                            |
-| `logout`           | Logout from Maestro Cloud.                                                           |
-| `mcp`              | Start the Maestro Model Context Protocol (MCP).                                      |
-| `record`           | Record your Flows.                                                                   |
-| `start-device`     | Start an iOS Simulator or an Android Emulator.                                       |
-| `test`             | Test a Flow or a selected set of Flows on a local iOS Simulator or Android Emulator. |
+| `download-samples`    | Download sample Flows and sample apps for running with the Maestro CLI.              |
+| `driver-setup`        | Setup Maestro drivers for your device.                                               |
+| `list-cloud-devices`  | List devices available on Maestro Cloud, grouped by platform.                        |
+| `list-devices`        | List local devices available, grouped by platform.                                   |
+| `login`               | Login into Maestro Cloud.                                                            |
+| `logout`              | Logout from Maestro Cloud.                                                           |
+| `mcp`                 | Start the Maestro Model Context Protocol (MCP).                                      |
+| `record`              | Record your Flows.                                                                   |
+| `start-device`        | Start an iOS Simulator or an Android Emulator.                                       |
+| `test`                | Test a Flow or a selected set of Flows on a local iOS Simulator or Android Emulator. |
 
 ### Subcommand Options
 
@@ -92,7 +94,7 @@ Upload and run your flows on Maestro Cloud.
 
 | Option                                      | Description                                                           |
 | ------------------------------------------- | --------------------------------------------------------------------- |
-| `--android-api-level=<level>`               | Android API level to run your flow against.                           |
+| `--android-api-level=<level>`               | (Deprecated) Android API level. Use `--device-os` instead.            |
 | `--apiKey`, `--api-key=<key>`               | API key for Maestro Cloud.                                            |
 | `--apiUrl`, `--api-url=<url>`               | API base URL.                                                         |
 | `--appBinaryId`, `--app-binary-id=<id>`     | The ID of an app binary previously uploaded to Maestro Cloud.         |
@@ -102,8 +104,8 @@ Upload and run your flows on Maestro Cloud.
 | `--commitSha`, `--commit-sha=<sha>`         | The commit SHA of this upload.                                        |
 | `--config=<file>`                           | Optional .yaml configuration file for Flows.                          |
 | `--device-locale=<locale>`                  | Locale for the device (e.g., "de\_DE" for Germany).                   |
-| `--device-model=<model>`                    | iOS device model to run against (e.g., iPhone-11).                    |
-| `--device-os=<os>`                          | iOS version to run against (e.g., iOS-17-5, iOS-18-2).                |
+| `--device-model=<model>`                    | Device model to run against. iOS: `iPhone-11`, `iPhone-11-Pro`, etc. Android: `pixel_6`, `pixel_7`, etc. Run `maestro list-cloud-devices` to see all supported models. |
+| `--device-os=<os>`                          | OS version to run against. iOS: `iOS-16-2`, `iOS-17-5`, `iOS-18-2`, etc. Android: `android-33`, `android-34`, etc. Run `maestro list-cloud-devices` to see all supported versions. |
 | `-e`, `--env=<Key=Value>`                   | Environment variables to inject into your Flows.                      |
 | `--exclude-tags=<tags>`                     | List of tags that will remove the Flows containing the provided tags. |
 | `--flows=<path>`                            | A Flow path or a folder path that contains Flows.                     |
@@ -147,10 +149,30 @@ Launch an emulator or simulator.
 | Option                     | Description                                                                             |
 | -------------------------- | --------------------------------------------------------------------------------------- |
 | `--device-locale=<locale>` | Combination of lowercase ISO-639-1 code and uppercase ISO-3166-1 code (e.g., "de\_DE"). |
+| `--device-model=<model>`   | Device model to run against. iOS: `iPhone-11`, `iPhone-11-Pro`, etc. Android: `pixel_6`, `pixel_7`, etc. Run `maestro list-devices` to see all supported models. |
+| `--device-os=<os>`         | OS version to use. iOS: `iOS-16-2`, `iOS-17-5`, `iOS-18-2`, etc. Android: `android-33`, `android-34`, etc. Run `maestro list-devices` to see all supported versions. |
 | `--force-create`           | Overrides the existing device if it already exists.                                     |
 | `-h`, `--help`             | Display the help message.                                                               |
-| `--os-version=<version>`   | OS version to use. iOS: 16, 17, 18. Android: 28, 29, 30, 31, 33.                        |
+| `--os-version=<version>`   | (Deprecated) OS version. Use `--device-os` instead.                                     |
 | `--platform=<platform>`    | Platforms: `android`, `ios`, or `web`                                                   |
+
+#### `list-devices`
+
+List local devices available, grouped by platform.
+
+| Option                     | Description                                          |
+| -------------------------- | ---------------------------------------------------- |
+| `-h`, `--help`             | Display the help message.                            |
+| `--platform=<platform>`    | Filter by platform: `android`, `ios`, or `web`.      |
+
+#### `list-cloud-devices`
+
+List devices available on Maestro Cloud, grouped by platform.
+
+| Option                     | Description                                          |
+| -------------------------- | ---------------------------------------------------- |
+| `-h`, `--help`             | Display the help message.                            |
+| `--platform=<platform>`    | Filter by platform: `android`, `ios`, or `web`.      |
 
 ### Named parameters
 

--- a/maestro-cli/maestro-cli-commands-and-options.md
+++ b/maestro-cli/maestro-cli-commands-and-options.md
@@ -104,8 +104,8 @@ Upload and run your flows on Maestro Cloud.
 | `--commitSha`, `--commit-sha=<sha>`         | The commit SHA of this upload.                                        |
 | `--config=<file>`                           | Optional .yaml configuration file for Flows.                          |
 | `--device-locale=<locale>`                  | Locale for the device (e.g., "de\_DE" for Germany).                   |
-| `--device-model=<model>`                    | Device model to run against. iOS: `iPhone-11`, `iPhone-11-Pro`, etc. Android: `pixel_6`, `pixel_7`, etc. Run `maestro list-cloud-devices` to see all supported models. |
-| `--device-os=<os>`                          | OS version to run against. iOS: `iOS-16-2`, `iOS-17-5`, `iOS-18-2`, etc. Android: `android-33`, `android-34`, etc. Run `maestro list-cloud-devices` to see all supported versions. |
+| `--device-model=<model>`                    | Device model to run against. iOS: `iPhone-11`, `iPhone-17-Pro`, etc. Android: `pixel_6`, `pixel_7`, etc. Run `maestro list-cloud-devices` to see all supported models. |
+| `--device-os=<os>`                          | OS version to run against. iOS: `iOS-18-2`, `iOS-26-2` etc. Android: `android-33`, `android-34`, etc. Run `maestro list-cloud-devices` to see all supported versions. |
 | `-e`, `--env=<Key=Value>`                   | Environment variables to inject into your Flows.                      |
 | `--exclude-tags=<tags>`                     | List of tags that will remove the Flows containing the provided tags. |
 | `--flows=<path>`                            | A Flow path or a folder path that contains Flows.                     |


### PR DESCRIPTION
## Summary

Updates the docs to reflect recent Maestro CLI changes:

- New `maestro list-devices` and `maestro list-cloud-devices` commands (each with a `--platform` filter).
- `start-device`: `--os-version` is deprecated; use `--device-model` and `--device-os` (e.g. `iPhone-11`, `pixel_6`, `iOS-18-2`, `android-34`).
- `cloud`: `--ios-version` and `--android-api-level` are deprecated; `--device-model` / `--device-os` now cover both iOS and Android with the new identifier format.

### Files changed

- `maestro-cli/maestro-cli-commands-and-options.md` — added `list-devices` and `list-cloud-devices` to the subcommands table and added reference sections for them; updated `cloud` and `start-device` option tables (deprecations + Android coverage on `--device-model` / `--device-os`).
- `flows/flow-control-and-logic/specify-and-start-devices.md` — refreshed the `start-device` help-output example and added pointers to `maestro list-devices` / `maestro list-cloud-devices`.
- `cloud/ci-cd-integration/github-actions/README.md` — marked `android-api-level` deprecated and broadened `device-model` / `device-os` to cover Android.
- `cloud/ci-cd-integration/github-actions/platform-guides.md` — replaced the Android API level snippet with `device-os` + `device-model`; added deprecation hints on both Android and iOS tabs.

`cloud/environment-configuration/configure-the-os.md` already used the new flag format and did not need changes.