### PR TITLE
Document deprecated device flags in CI/CD integrations

### DIFF
--- a/cloud/ci-cd-integration/bitrise.md
+++ b/cloud/ci-cd-integration/bitrise.md
@@ -44,6 +44,29 @@ Visit the [Maestro Step in the Bitrise catalog](https://bitrise.io/integrations/
 
 Once configured, Bitrise automatically triggers your Maestro tests in the cloud as part of your pipeline.
 
+#### Device configuration
+
+To target a specific OS version or device model, use the `device_os` and `device_model` inputs. Both inputs accept iOS and Android values.
+
+```yaml
+- maestro-cloud-upload@1:
+    inputs:
+    - api_key: $CLOUD_API_KEY
+    - project_id: $MAESTRO_PROJECT_ID
+    - app_file: $BITRISE_APK_PATH
+    - device_os: android-34
+    - device_model: pixel_6
+```
+
+| Input          | Description                                                                              | Example                    |
+| -------------- | ---------------------------------------------------------------------------------------- | -------------------------- |
+| `device_os`    | OS version to run against. Run `maestro list-cloud-devices` to see all supported values. | `iOS-26-2`, `android-34`     |
+| `device_model` | Device model to run against. Run `maestro list-cloud-devices` to see all supported values. | `iPhone-17-Pro`, `pixel_6` |
+
+{% hint style="warning" %}
+The `android_api_level` input is **deprecated** in favor of `device_os`. Existing workflows that set `android_api_level` continue to work but emit a deprecation warning. Migrate to `device_os` (e.g. `device_os: android-34`) when convenient.
+{% endhint %}
+
 #### Next steps
 
 Now that your CI pipeline is connected, consider optimizing your cloud runs:

--- a/cloud/ci-cd-integration/github-actions/README.md
+++ b/cloud/ci-cd-integration/github-actions/README.md
@@ -112,13 +112,16 @@ Below are all available inputs for the `mobile-dev-inc/action-maestro-cloud` act
 
 #### Device configuration
 
-| Input               | Description                                                                                       | Example        |
-| ------------------- | ------------------------------------------------------------------------------------------------- | -------------- |
-| `android-api-level` | Android API level. (Deprecated - use `device-os` instead.)                                        | `30`           |
-| `device-model`      | Device model to run against. Run `maestro list-cloud-devices` to see all supported models.                                                                         | `iPhone-16` , `pixel_6` |
-| `device-os`         | OS version to run against. Run `maestro list-cloud-devices` to see all supported versions.                                                                             | `iOS-18-2`, `android-34` |
-| `device-locale`     | Device locale (ISO-639-1 + ISO-3166-1).                                                           | `de_DE`        |
-| `mapping-file`      | Path to ProGuard map (Android) or dSYM (iOS).                                                     | `./MyApp.dSYM` |
+| Input           | Description                                                                                  | Example                  |
+| --------------- | -------------------------------------------------------------------------------------------- | ------------------------ |
+| `device-model`  | Device model to run against. Run `maestro list-cloud-devices` to see all supported values.   | `iPhone-17-Pro`, `pixel_6` |
+| `device-os`     | OS version to run against. Run `maestro list-cloud-devices` to see all supported values.     | `iOS-26-2`, `android-34`   |
+| `device-locale` | Device locale (ISO-639-1 + ISO-3166-1).                                                      | `de_DE`                  |
+| `mapping-file`  | Path to ProGuard map (Android) or dSYM (iOS).                                                | `./MyApp.dSYM`           |
+
+{% hint style="warning" %}
+The `android-api-level` and `ios-version` inputs are **deprecated** in favor of `device-os`. Existing workflows that set them continue to work but emit a deprecation warning. Migrate to `device-os` (e.g. `device-os: android-34` or `device-os: iOS-26-2`) when convenient.
+{% endhint %}
 
 {% hint style="info" %}
 Access the [configure-the-os.md](../../environment-configuration/configure-the-os.md "mention") page for more information.

--- a/cloud/ci-cd-integration/github-actions/platform-guides.md
+++ b/cloud/ci-cd-integration/github-actions/platform-guides.md
@@ -60,7 +60,7 @@ The default API level on Maestro Cloud is 33 (Android 13). You can override the 
 with:
   # ... other inputs
   device-model: pixel_6
-  device-os: android-29
+  device-os: android-34
 ```
 
 {% hint style="info" %}
@@ -151,8 +151,8 @@ The default iOS version is 16. You can specify a different OS version or device 
 ```yaml
 with:
   # ... other inputs
-  device-model: iPhone-16
-  device-os: iOS-18-2
+  device-model: iPhone-17-Pro
+  device-os: iOS-26-2
 ```
 
 {% hint style="info" %}


### PR DESCRIPTION
## Summary

- Surface the [`action-maestro-cloud#65`](https://github.com/mobile-dev-inc/action-maestro-cloud/pull/65) and [`bitrise-step-maestro-cloud-upload#31`](https://github.com/mobile-dev-inc/bitrise-step-maestro-cloud-upload/pull/31) deprecations in the docs: `android-api-level` / `android_api_level` / `ios-version` are superseded by `device-os` (the deprecated inputs still work but emit warnings).
- Pull the deprecated row out of the GitHub Actions inputs table into a dedicated warning callout, mirroring the action's own README.
- Add a new "Device configuration" section to the Bitrise page (previously had no flag-level guidance) covering `device_os` / `device_model` and the `android_api_level` deprecation.
- Align all CI/CD examples to the canonical pair already used in `configure-the-os.md`: iOS → `iOS-26-2` / `iPhone-17-Pro`, Android → `android-34` / `pixel_6`.

## Files changed

- `cloud/ci-cd-integration/github-actions/README.md` — table + migration callout
- `cloud/ci-cd-integration/github-actions/platform-guides.md` — iOS and Android device snippets
- `cloud/ci-cd-integration/bitrise.md` — new device configuration section + deprecation callout