### PR TITLE
Add Codex Desktop App to Maestro MCP docs

### DIFF
--- a/introduction/get-started/maestro-mcp.md
+++ b/introduction/get-started/maestro-mcp.md
@@ -80,7 +80,7 @@ Otherwise:
     * **Command to launch:** `maestro`
     * **Arguments:** `mcp`
 
-    Then click **Save**.
+    Then click **Save** and restart the Codex Desktop App for the new server to be picked up.
 
 See the [Codex MCP docs](https://developers.openai.com/codex/mcp) and the [config reference](https://developers.openai.com/codex/config-reference).
 

--- a/introduction/get-started/maestro-mcp.md
+++ b/introduction/get-started/maestro-mcp.md
@@ -114,6 +114,8 @@ See the [Codex MCP docs](https://developers.openai.com/codex/mcp) and the [confi
 
     Claude Desktop launches from a minimal shell, so pass `JAVA_HOME` explicitly and use the full path to the `maestro` binary (run `which maestro` in your terminal to find it).
 
+    After saving the config, restart Claude Desktop for the new server to be picked up.
+
 {% hint style="info" %}
 The **Connectors** UI in Claude Desktop only supports remote MCP servers that use OAuth. Local stdio servers like Maestro must be added by editing `claude_desktop_config.json` directly.
 {% endhint %}

--- a/introduction/get-started/maestro-mcp.md
+++ b/introduction/get-started/maestro-mcp.md
@@ -42,6 +42,40 @@ See the [Claude Code MCP docs](https://docs.claude.com/en/docs/claude-code/mcp) 
 
 <details>
 
+<summary><i class="fa-claude">:claude:</i>  Claude Desktop</summary>
+
+1. [Install the Maestro CLI](https://docs.maestro.dev/maestro-cli/how-to-install-maestro-cli).
+2.  In Claude Desktop, open **Settings → Developer → Edit Config** and merge the following into `claude_desktop_config.json`:
+
+    ```json
+    {
+        "mcpServers": {
+            "maestro": {
+                "command": "<full path to maestro binary>",
+                "args": ["mcp"],
+                "env": {
+                    "JAVA_HOME": "<full JAVA_HOME directory>"
+                }
+            }
+        }
+    }
+    ```
+
+    The config file lives at:
+
+    * **macOS:** `~/Library/Application Support/Claude/claude_desktop_config.json`
+    * **Windows:** `%APPDATA%\Claude\claude_desktop_config.json`
+
+    Claude Desktop launches from a minimal shell, so pass `JAVA_HOME` explicitly and use the full path to the `maestro` binary (run `which maestro` in your terminal to find it).
+
+{% hint style="info" %}
+The **Connectors** UI in Claude Desktop only supports remote MCP servers that use OAuth. Local stdio servers like Maestro must be added by editing `claude_desktop_config.json` directly.
+{% endhint %}
+
+</details>
+
+<details>
+
 <summary><i class="fa-chatgpt">:chatgpt:</i>  Codex CLI</summary>
 
 1. [Install the Maestro CLI](https://docs.maestro.dev/maestro-cli/how-to-install-maestro-cli).
@@ -83,40 +117,6 @@ Otherwise:
     Then click **Save**.
 
 See the [Codex MCP docs](https://developers.openai.com/codex/mcp) and the [config reference](https://developers.openai.com/codex/config-reference).
-
-</details>
-
-<details>
-
-<summary><i class="fa-claude">:claude:</i>  Claude Desktop</summary>
-
-1. [Install the Maestro CLI](https://docs.maestro.dev/maestro-cli/how-to-install-maestro-cli).
-2.  In Claude Desktop, open **Settings → Developer → Edit Config** and merge the following into `claude_desktop_config.json`:
-
-    ```json
-    {
-        "mcpServers": {
-            "maestro": {
-                "command": "<full path to maestro binary>",
-                "args": ["mcp"],
-                "env": {
-                    "JAVA_HOME": "<full JAVA_HOME directory>"
-                }
-            }
-        }
-    }
-    ```
-
-    The config file lives at:
-
-    * **macOS:** `~/Library/Application Support/Claude/claude_desktop_config.json`
-    * **Windows:** `%APPDATA%\Claude\claude_desktop_config.json`
-
-    Claude Desktop launches from a minimal shell, so pass `JAVA_HOME` explicitly and use the full path to the `maestro` binary (run `which maestro` in your terminal to find it).
-
-{% hint style="info" %}
-The **Connectors** UI in Claude Desktop only supports remote MCP servers that use OAuth. Local stdio servers like Maestro must be added by editing `claude_desktop_config.json` directly.
-{% endhint %}
 
 </details>
 

--- a/introduction/get-started/maestro-mcp.md
+++ b/introduction/get-started/maestro-mcp.md
@@ -67,18 +67,20 @@ See the [Codex MCP docs](https://developers.openai.com/codex/mcp) and the [confi
 
 <summary><i class="fa-chatgpt">:chatgpt:</i>  Codex Desktop App</summary>
 
-The Codex Desktop App shares its MCP config with the Codex CLI and IDE extension. If Maestro is already set up there, the Desktop App will pick it up automatically.
+The Codex Desktop App shares its MCP config (`~/.codex/config.toml`) with the Codex CLI. If Maestro is already set up there, the Desktop App will pick it up automatically.
 
 Otherwise:
 
 1. [Install the Maestro CLI](https://docs.maestro.dev/maestro-cli/how-to-install-maestro-cli).
-2.  In the Codex Desktop App, open the gear menu and select **MCP settings → Open config.toml**. Merge the following into `~/.codex/config.toml`:
+2. In the Codex Desktop App, click the **Settings** button, then **Settings** again, and select **MCP servers** in the sidebar.
+3.  Click **Add server** and fill in the form:
 
-    ```toml
-    [mcp_servers.maestro]
-    command = "maestro"
-    args = ["mcp"]
-    ```
+    * **Name:** `maestro`
+    * **Type:** `STDIO`
+    * **Command to launch:** `maestro`
+    * **Arguments:** `mcp`
+
+    Then click **Save**.
 
 See the [Codex MCP docs](https://developers.openai.com/codex/mcp) and the [config reference](https://developers.openai.com/codex/config-reference).
 

--- a/introduction/get-started/maestro-mcp.md
+++ b/introduction/get-started/maestro-mcp.md
@@ -80,7 +80,7 @@ Otherwise:
     * **Command to launch:** `maestro`
     * **Arguments:** `mcp`
 
-    Then click **Save** and restart the Codex Desktop App for the new server to be picked up.
+    Then click **Save**.
 
 See the [Codex MCP docs](https://developers.openai.com/codex/mcp) and the [config reference](https://developers.openai.com/codex/config-reference).
 
@@ -113,8 +113,6 @@ See the [Codex MCP docs](https://developers.openai.com/codex/mcp) and the [confi
     * **Windows:** `%APPDATA%\Claude\claude_desktop_config.json`
 
     Claude Desktop launches from a minimal shell, so pass `JAVA_HOME` explicitly and use the full path to the `maestro` binary (run `which maestro` in your terminal to find it).
-
-    After saving the config, restart Claude Desktop for the new server to be picked up.
 
 {% hint style="info" %}
 The **Connectors** UI in Claude Desktop only supports remote MCP servers that use OAuth. Local stdio servers like Maestro must be added by editing `claude_desktop_config.json` directly.

--- a/introduction/get-started/maestro-mcp.md
+++ b/introduction/get-started/maestro-mcp.md
@@ -6,7 +6,7 @@ description: >-
 
 # Maestro MCP Server
 
-Maestro implements the [Model Context Protocol (MCP)](https://modelcontextprotocol.io/docs/getting-started/intro), enabling direct integration coding agents like Claude Code, Claude Desktop, Cursor, GitHub Copilot, Codex, Gemini, Windsurf, and JetBrains AI Assistant ([full list](https://modelcontextprotocol.io/clients)). For more information on MCP see [#what-is-mcp](maestro-mcp.md#what-is-mcp "mention").
+Maestro implements the [Model Context Protocol (MCP)](https://modelcontextprotocol.io/docs/getting-started/intro), enabling direct integration coding agents like Claude Code, Claude Desktop, Cursor, GitHub Copilot, Codex, Codex Desktop, Gemini, Windsurf, and JetBrains AI Assistant ([full list](https://modelcontextprotocol.io/clients)). For more information on MCP see [#what-is-mcp](maestro-mcp.md#what-is-mcp "mention").
 
 {% embed url="https://files.gitbook.com/v0/b/gitbook-x-prod.appspot.com/o/spaces%2FCbCMt5C3rawmE9oIus7f%2Fuploads%2FmkNE7cEla6mI7Ikp0aH5%2Fmaestro-mcp.mp4?alt=media&token=b63eb192-ce07-4614-878c-69cf447eae2e" %}
 
@@ -52,6 +52,27 @@ See the [Claude Code MCP docs](https://docs.claude.com/en/docs/claude-code/mcp) 
     ```
 
     Or add to `~/.codex/config.toml` manually:
+
+    ```toml
+    [mcp_servers.maestro]
+    command = "maestro"
+    args = ["mcp"]
+    ```
+
+See the [Codex MCP docs](https://developers.openai.com/codex/mcp) and the [config reference](https://developers.openai.com/codex/config-reference).
+
+</details>
+
+<details>
+
+<summary><i class="fa-chatgpt">:chatgpt:</i>  Codex Desktop App</summary>
+
+The Codex Desktop App shares its MCP config with the Codex CLI and IDE extension. If Maestro is already set up there, the Desktop App will pick it up automatically.
+
+Otherwise:
+
+1. [Install the Maestro CLI](https://docs.maestro.dev/maestro-cli/how-to-install-maestro-cli).
+2.  In the Codex Desktop App, open the gear menu and select **MCP settings → Open config.toml**. Merge the following into `~/.codex/config.toml`:
 
     ```toml
     [mcp_servers.maestro]
@@ -312,6 +333,14 @@ Restart Claude Desktop.
 <summary><i class="fa-chatgpt">:chatgpt:</i>  Codex CLI</summary>
 
 Restart the Codex CLI.
+
+</details>
+
+<details>
+
+<summary><i class="fa-chatgpt">:chatgpt:</i>  Codex Desktop App</summary>
+
+Restart the Codex Desktop App.
 
 </details>
 


### PR DESCRIPTION
## Summary
- Add Codex Desktop App to the supported-agents list in the Maestro MCP intro
- New install entry for Codex Desktop, noting it shares `~/.codex/config.toml` with the Codex CLI / IDE extension and showing the gear-menu → MCP settings → Open config.toml flow
- New reload entry under "How to Update Maestro MCP" (restart the Codex Desktop App)

## Test plan
- [x] Preview renders correctly in GitBook
- [x] Collapsible sections expand as expected
- [x] Links to OpenAI Codex MCP / config-reference docs resolve

🤖 Generated with [Claude Code](https://claude.com/claude-code)