### PR TITLE
Update PowerShell PATH setup for Maestro CLI

### DIFF
--- a/maestro-cli/how-to-install-maestro-cli/README.md
+++ b/maestro-cli/how-to-install-maestro-cli/README.md
@@ -55,9 +55,7 @@ Install using the [releases page on GitHub](https://github.com/mobile-dev-inc/Ma
 3.  Update your `PATH` to add the Maestro CLI environment variable. Run the following in PowerShell to add the Maestro `bin` folder to your environment variables:<br>
 
     ```powershell
-    $oldPath = [Environment]::GetEnvironmentVariable("Path", "User")
-    $newPath = "$oldPath;C:\maestro\bin"
-    [Environment]::SetEnvironmentVariable("Path", $newPath, "User")
+    [Environment]::SetEnvironmentVariable("Path", "$Env:PATH;c:\maestro\bin", "User")
     ```
 4. Restart your terminal to apply changes.
 

--- a/maestro-cli/how-to-install-maestro-cli/README.md
+++ b/maestro-cli/how-to-install-maestro-cli/README.md
@@ -55,7 +55,9 @@ Install using the [releases page on GitHub](https://github.com/mobile-dev-inc/Ma
 3.  Update your `PATH` to add the Maestro CLI environment variable. Run the following in PowerShell to add the Maestro `bin` folder to your environment variables:<br>
 
     ```powershell
-    setx PATH "%PATH%;C:\maestro\bin"
+    $oldPath = [Environment]::GetEnvironmentVariable("Path", "User")
+    $newPath = "$oldPath;C:\maestro\bin"
+    [Environment]::SetEnvironmentVariable("Path", $newPath, "User")
     ```
 4. Restart your terminal to apply changes.
 


### PR DESCRIPTION
The previous example used setx PATH "%PATH%;C:\maestro\bin", which can lead to unexpected issues on Windows. setx expands environment variables before writing them back and may permanently replace references such as %JAVA_HOME% with their current values. It can also overwrite or truncate existing PATH entries in some scenarios.

The updated command uses the .NET Environment API to read and update the user PATH directly, preserving the existing value without relying on %PATH% expansion. This approach is more reliable and aligns with current Windows best practices for modifying environment variables.

---

This pull request updates the Windows installation instructions for Maestro CLI to use a more robust method for adding the Maestro `bin` folder to the user's `PATH` environment variable in PowerShell.

**Documentation improvements:**

* [`maestro-cli/how-to-install-maestro-cli/README.md`](diffhunk://#diff-053786bd3d4997f74bdeb80a5b98721d638279434b189b8395fea492a27520f0L58-R60): Replaced the previous `setx` command with a PowerShell script that safely appends `C:\maestro\bin` to the user's `PATH`, ensuring the existing `PATH` is preserved.