### PR TITLE
Clarify Maestro artifact folder contents

### DIFF
--- a/flows/workspace-management/test-reports-and-artifacts.md
+++ b/flows/workspace-management/test-reports-and-artifacts.md
@@ -119,8 +119,7 @@ The contents of your artifact folders depend on which output directory you confi
 | `--debug-output` only | `maestro.log`, while screenshots, video, `commands-*.json`, and AI Reports go to the default test output tree. |
 | Both flags specified | `--debug-output` receives only `maestro.log`, and `--test-output-dir` receives screenshots, video, `commands-*.json`, and AI Reports. |
 
-* **Same directory**: If both flags point to the same location, all artifacts are consolidated into that single folder.
-* **Different directories**: If the flags point to different directories, the `--debug-output` directory receives **only** `maestro.log`, while the `--test-output-dir` receives everything else.
+If both flags point to the same directory, all artifacts are consolidated there; otherwise, `--debug-output` receives only `maestro.log`, and `--test-output-dir` receives everything else.
 
 ### Next steps
 

--- a/flows/workspace-management/test-reports-and-artifacts.md
+++ b/flows/workspace-management/test-reports-and-artifacts.md
@@ -110,17 +110,17 @@ properties:
 
 #### What's inside the Artifact Folder?
 
-The contents of your artifact folders depend on which output directory you configure and whether you use one or both CLI flags:
+The contents of your artifact folders depend on which output directory you configure and whether you use one or both CLI flags.
 
-| **Output directory** | **Primary contents** | **Notes** |
-| -------------------- | -------------------- | --------- |
-| `--test-output-dir`  | Screenshots & Video, `commands-*.json`, AI Reports | In single-flag runs, Maestro can also place `maestro.log` under the same run tree. |
-| `--debug-output`     | `maestro.log` | In single-flag runs, screenshots and `commands-*.json` can also appear under the default test output tree. |
-
-When using both flags, you must consider the following behaviour:
+| Case | Feature |
+| ---- | ------- |
+| Neither flag specified | Maestro uses the default output directories described in the [Output directory](#output-directory) section. |
+| `--test-output-dir` only | Screenshots & Video, `commands-*.json`, AI Reports, and `maestro.log` under the same run tree. |
+| `--debug-output` only | `maestro.log`, while screenshots, video, `commands-*.json`, and AI Reports go to the default test output tree. |
+| Both flags specified | `--debug-output` receives only `maestro.log`, and `--test-output-dir` receives screenshots, video, `commands-*.json`, and AI Reports. |
 
 * **Same directory**: If both flags point to the same location, all artifacts are consolidated into that single folder.
-* **Different directories**: If the flags point to different directories, the `--debug-output` directory will receive **only** the `maestro.log`, while the `--test-output-dir` will receive everything else (Screenshots, Videos, Commands JSON, and AI Reports).
+* **Different directories**: If the flags point to different directories, the `--debug-output` directory receives **only** `maestro.log`, while the `--test-output-dir` receives everything else.
 
 ### Next steps
 

--- a/flows/workspace-management/test-reports-and-artifacts.md
+++ b/flows/workspace-management/test-reports-and-artifacts.md
@@ -117,9 +117,7 @@ The contents of your artifact folders depend on which output directory you confi
 | Neither flag specified | Maestro uses the default output directories described in the [Output directory](#output-directory) section. |
 | `--test-output-dir` only | Screenshots & Video, `commands-*.json`, AI Reports, and `maestro.log` under the same run tree. |
 | `--debug-output` only | `maestro.log`, while screenshots, video, `commands-*.json`, and AI Reports go to the default test output tree. |
-| Both flags specified | `--debug-output` receives only `maestro.log`, and `--test-output-dir` receives screenshots, video, `commands-*.json`, and AI Reports. |
-
-If both flags point to the same directory, all artifacts are consolidated there; otherwise, `--debug-output` receives only `maestro.log`, and `--test-output-dir` receives everything else.
+| Both flags specified | Unless they both point to the same directory, `--debug-output` receives only `maestro.log`, and `--test-output-dir` receives screenshots, video, `commands-*.json`, and AI Reports. |
 
 ### Next steps
 

--- a/flows/workspace-management/test-reports-and-artifacts.md
+++ b/flows/workspace-management/test-reports-and-artifacts.md
@@ -110,14 +110,12 @@ properties:
 
 #### What's inside the Artifact Folder?
 
-The contents of your artifact folders depend on which CLI flag you use. Note that `--test-output-dir` and `--debug-output` capture different sets of data:
+The contents of your artifact folders depend on which output directory you configure and whether you use one or both CLI flags:
 
-| **Feature**         | **`--test-output-dir`** | **`--debug-output`** |
-| ------------------- | ----------------------- | -------------------- |
-| Screenshots & Video | Yes                     | No                   |
-| `maestro.log`       | No                      | Yes                  |
-| `commands-*.json`   | Yes                     | Yes                  |
-| AI Reports          | Yes                     | Yes                  |
+| **Output directory** | **Primary contents** | **Notes** |
+| -------------------- | -------------------- | --------- |
+| `--test-output-dir`  | Screenshots & Video, `commands-*.json`, AI Reports | In single-flag runs, Maestro can also place `maestro.log` under the same run tree. |
+| `--debug-output`     | `maestro.log` | In single-flag runs, screenshots and `commands-*.json` can also appear under the default test output tree. |
 
 When using both flags, you must consider the following behaviour:
 


### PR DESCRIPTION
  **Motivation:**

  - Clarify the documentation so the artifact folder section matches the actual layout more closely.
  - Reduce repetition in the [What's inside the Artifact Folder?](https://docs.maestro.dev/maestro-flows/workspace-management/test-reports-and-artifacts#whats-inside-the-artifact-folder) section.

  **What changed:**

  - Replace the Yes/No matrix with a table that describes the primary contents per output directory.
  - Add a concise note explaining how artifacts are split when both flags point to the same directory versus different directories.
  - Keep the documentation aligned with the implementation in Maestro.